### PR TITLE
Fixes #257: Fix DB changelog for deleted users

### DIFF
--- a/Sources/styles/1/scss/_cpanel-admin.scss
+++ b/Sources/styles/1/scss/_cpanel-admin.scss
@@ -39,7 +39,8 @@
 }
 
 .log_user_td,
-.log_name_td, log_subname_td {
+.log_name_td,
+.log_subname_td {
     width: 20%;
     padding-left: 2px;
     font-size: 10pt;

--- a/Website/AtariLegend/php/admin/administration/change_log.php
+++ b/Website/AtariLegend/php/admin/administration/change_log.php
@@ -160,8 +160,23 @@ while ($log = $sql_log->fetch_array(MYSQLI_BOTH)) {
     //  the USER SECTION
     if ($log['section'] == 'Users') {
         if ($log['sub_section'] == 'Avatar' or $log['sub_section'] == 'User') {
-            $section_link    = ("../user/user_detail.php" . '?user_id_selected=' . $log['section_id']);
-            $subsection_link = ("../user/user_detail.php" . '?user_id_selected=' . $log['sub_section_id']);
+            if ($user_name == '0') {
+                // This is a log event about a deleted user (e.g. an avatar change or profile update)
+                // As they're deleted, we can't link to their profile
+                $section_link = '';
+                $subsection_link = '';
+            } else {
+                $section_link    = ("../user/user_detail.php" . '?user_id_selected=' . $log['section_id']);
+                $subsection_link = ("../user/user_detail.php" . '?user_id_selected=' . $log['sub_section_id']);
+            }
+        }
+
+        if ($log['sub_section'] == 'User' and $log['action'] == 'Delete') {
+            // This is the log event when a user deleted another user
+            // The deleted user doesn't exist in the database anymore, so we
+            // can't link to their profile
+            $section_link = '';
+            $subsection_link = '';
         }
     }
 

--- a/Website/AtariLegend/themes/templates/1/admin/change_log.html
+++ b/Website/AtariLegend/themes/templates/1/admin/change_log.html
@@ -79,32 +79,52 @@ The change log page
 							{$line.log_date}
 						</td>
 						<td class="log_user_td">
+							{if $line.log_user_name <> '0'}
 							<a href="../user/user_detail.php?user_id_selected={$line.log_user_id}" class="standard_table_left">
 								{$line.log_user_name}
 							</a>
+							{else}
+								[deleted user]
+							{/if}
 						</td>
 						<td class="log_section_td">
-							<a href="{$line.log_section_link}" class="standard_table_left">
+							{if $line.log_section_link <> ''}
+								<a href="{$line.log_section_link}" class="standard_table_left">
+									{$line.log_section}
+								</a>
+							{else}
 								{$line.log_section}
-							</a>
+							{/if}
 						</td>
 						<td class="log_name_td">
-							<a href="{$line.log_section_link}" class="standard_table_left">
+							{if $line.log_section_link <> ''}
+								<a href="{$line.log_section_link}" class="standard_table_left">
+									{$line.log_section_name}
+								</a>
+							{else}
 								{$line.log_section_name}
-							</a>
+							{/if}
 						</td>
 						<td class="log_action_td">
 							{$line.log_action}
 						</td>
 						<td class="log_subsection_td">
-							<a href="{$line.log_subsection_link}" class="standard_table_left">
+							{if $line.log_subsection_link <> ''}
+								<a href="{$line.log_subsection_link}" class="standard_table_left">
+									{$line.log_subsection}
+								</a>
+							{else}
 								{$line.log_subsection}
-							</a>
+							{/if}
 						</td>
 						<td class="log_subname_td">
-							<a href="{$line.log_subsection_link}" class="standard_table_left">
+							{if $line.log_subsection_link <> ''}
+								<a href="{$line.log_subsection_link}" class="standard_table_left">
+									{$line.log_subsection_name}
+								</a>
+							{else}
 								{$line.log_subsection_name}
-							</a>
+							{/if}
 						</td>
 					</tr>
 					{/foreach}


### PR DESCRIPTION
Deleted users don't have a profile anymore so we can't link to their
profile page from the DB changelog page.

Changes:
* The deleted user will now show as `[deleted user]` in the changelog
page rather than `0`
* When the DB changelog event is about a deleted user, or the actual
deletion event by another user, remove the links to the deleted user profile
* Updated Smarty templates accordingly for the case when the link is
missing
* Fixed CSS, a missing dot `.` before the class name was causing the
"Sub name" column to appear in larger black text as the class didn't
apply.