### PR TITLE
Fixes #247: Fix ENTER key on the search forms

### DIFF
--- a/Sources/styles/common/main_scss/_menu.scss
+++ b/Sources/styles/common/main_scss/_menu.scss
@@ -254,11 +254,14 @@ html {
 
 @if $skin-name == legacy {
     #search_side {
+        border: none;
+        border-bottom: 3px solid #008b8b;
         background-image: url('../images/menu_search.png');
         background-size: cover;
         background-repeat: no-repeat;
+        padding-bottom: 1px;
         padding-left: 50px;
-        padding-top: 40px;
+        padding-top: 19px;
     }
     #searchbutton_side {
         background: $bg-color;
@@ -638,7 +641,7 @@ header nav li {
     display: inline-block;
 }
 
-header nav input {
+header nav input[type=text] {
     background-color: #000;
     color: #fff;
     width: 247px;
@@ -649,6 +652,9 @@ header nav input {
     display: block;
     text-align: center;
     font-size: $menu-input-font;
+}
+header nav input[type=submit] {
+    border: none;
 }
 
 .top_button_extra {

--- a/Website/AtariLegend/themes/templates/1/main/main.html
+++ b/Website/AtariLegend/themes/templates/1/main/main.html
@@ -53,7 +53,7 @@
                     source: function(request, response) {
                         $.getJSON(
                             "../../../php/includes/autocomplete.php?",
-                            { term:request.term, extraParams:$('#autocomplete1').val() },
+                            { term:request.term, extraParams: 'title' },
                             response
                         );
                     },
@@ -67,7 +67,7 @@
                     source: function(request, response) {
                         $.getJSON(
                             "../../../php/includes/autocomplete.php?",
-                            { term:request.term, extraParams:$('#autocomplete1').val() },
+                            { term:request.term, extraParams: 'title' },
                             response
                         );
                     },
@@ -136,16 +136,6 @@
                 {/if}
             });
         </script>
-        <script type="text/javascript"> <!-- Go to the game search results -->
-			function Search() {
-                var game_search = document.getElementById("auto").value;
-                {literal}
-                    if (!game_search) {game_search = document.getElementById("search_text_side").value;}
-                {/literal}
-                url="../games/games_main_list.php?gamesearch="+game_search+"&action=search";
-                location.href=url;
-            }
-		</script>
         {literal}
         <script> <!-- The 'go to the top' buttong -->
             $(function(){
@@ -207,11 +197,13 @@
                                         </ul>
                                 </nav>
                             </div>
-                            <ul id="search_ul">
-                                <li id="searchbutton_side"><input id="search_text_side" type="text" name="gamesearch" maxlength="11"></li>
-                                <input type="hidden" value="title" id="autocomplete1">
-                                <li><a href="#" onclick="Search()"><div id="search_side"></div></a></li>
-                            </ul>
+                            <form action="../games/games_main_list.php" method="get">
+                                <input type="hidden" name="action" value="search">
+                                <ul id="search_ul">
+                                    <li id="searchbutton_side"><input id="search_text_side" type="text" name="gamesearch" maxlength="11"></li>
+                                    <li><input type="submit" id="search_side" value=""></li>
+                                </ul>
+                            </form>
                             <div class="skin-wrap">
                                 <nav class="skin-menu">
                                   <ul class="clearfix">
@@ -306,20 +298,22 @@
 					{/if}
 				</div>
 				<nav id="main_nav">
-					<ul id="main_nav_ul">
-						<li><a href="../front/front.php" id="home"></a></li>
-						<li><a href="../news/news.php" class="topbutton" id="news">NEWS</a></li>
-						<li><a href="../games/games_main.php" class="topbutton" id="games">GAMES</a></li>
-						<li><a href="../games/games_reviews_main.php" class="topbutton" id="demos">REVIEWS</a></li>
-						<li><a href="../interviews/interviews_main.php" class="topbutton" id="music">INTERVIEWS</a></li>
-                        <li><a href="../front/front.php?action=construction" class="topbutton" id="links">LINKS</a></li>
-						<li><a href="../../admin/" class="topbutton" id="cpanel">CPANEL</a></li>
-						<li><a href="http://www.atari-forum.com" class="topbutton" id="forum_top">FORUM</a></li>
-						<li><a href="../classAL/classAL.php" class="topbutton" id="about">ABOUT</a></li>
-						<li><div class="searchbutton" id="search_text"><input type="text" id="auto"></div></li>
-                        <input type="hidden" value="title" id="autocomplete1">
-						<li><a href="javascript:Search();"><div id="search"></div></a></li>
-					</ul>
+					<form action="../games/games_main_list.php" method="get">
+						<input type="hidden" name="action" value="search">
+						<ul id="main_nav_ul">
+							<li><a href="../front/front.php" id="home"></a></li>
+							<li><a href="../news/news.php" class="topbutton" id="news">NEWS</a></li>
+							<li><a href="../games/games_main.php" class="topbutton" id="games">GAMES</a></li>
+							<li><a href="../games/games_reviews_main.php" class="topbutton" id="demos">REVIEWS</a></li>
+							<li><a href="../interviews/interviews_main.php" class="topbutton" id="music">INTERVIEWS</a></li>
+							<li><a href="../front/front.php?action=construction" class="topbutton" id="links">LINKS</a></li>
+							<li><a href="../../admin/" class="topbutton" id="cpanel">CPANEL</a></li>
+							<li><a href="http://www.atari-forum.com" class="topbutton" id="forum_top">FORUM</a></li>
+							<li><a href="../classAL/classAL.php" class="topbutton" id="about">ABOUT</a></li>
+							<li><div class="searchbutton" id="search_text"><input type="text" id="auto" name="gamesearch"></div></li>
+							<li><input type="submit" id="search" value=""></li>
+						</ul>
+					</form>
 				</nav>
 			</header>
 		</div>


### PR DESCRIPTION
The issue was that the search forms were not true HTML `<form>`, but
rather a standalone `<input>` some Javascript with a `<a>` to trigger
the search. That prevented the ENTER key to work, as the browser will
only submit a form on ENTER if it's an actual `<form>` tag.

To fix this, converted the search to actual `<form>`s. An added
benefit is that it simplifies the code a bit, since there's no need for
Javascript to submit such forms.

Modified the CSS accordingly to account for the change of the submit
buttons from `<div>`s into proper `<input type="submit">`