### PR TITLE
Further work on #247: Simplify autocomplete code

### DIFF
--- a/Sources/styles/common/main_scss/_menu.scss
+++ b/Sources/styles/common/main_scss/_menu.scss
@@ -267,7 +267,7 @@ html {
         background: $bg-color;
         height: 38px;
         width: 118px;
-        border-bottom: 2px solid #008b8b;
+        border-bottom: 3px solid #008b8b;
         border-left: 1px solid #007878;
         padding-top: 0;
     }

--- a/Website/AtariLegend/themes/templates/1/main/games_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_main.html
@@ -20,75 +20,13 @@ The main game page
 {block name=main_body}
     {literal}
     <script type="text/javascript"> <!-- script needed for the autocompletion search engine -->
-        $(function() {
-            $( "#gamesearch" ).autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete1').val() },
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
-            });
-
-            $('#games_main_pub_input').autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete2').val() },
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
-            });
-
-            $('#games_main_dev_input').autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete3').val() },
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
-            });
-
-            $('#games_main_year_input').autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete4').val() },
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
-            });
-
-            $('#games_main_cat_input').autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete5').val() },
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
+        $(document).ready(function() {
+            $(".autocompleted").each(function() {
+                var extraParam = $(this).attr("data-autocomplete-param");
+                $(this).autocomplete({
+                    source: "../../../php/includes/autocomplete.php?extraParams=" + extraParam,
+                    minLength: 2,
+                });
             });
         });
     </script>
@@ -304,8 +242,7 @@ The main game page
                         <div class="games_main_text_site_site"><h6>Title</h6></div>
                         <div class="games_main_text_short"><h6>:</h6></div>
                         <div class="games_main_input_site_text">
-                            <input type="text" name="gamesearch" value="" class="standard_tile_input_small_site" id="gamesearch">
-                            <input type="hidden" value="title" id="autocomplete1">
+                            <input type="text" name="gamesearch" value="" class="standard_tile_input_small_site autocompleted" id="gamesearch" data-autocomplete-param="title">
                         </div>
                     </div>
                     <div class="games_main_row_site">
@@ -318,8 +255,7 @@ The main game page
                                     <option value="{$line.comp_id}">{$line.comp_name}</option>
                                 {/foreach}
                             </select>
-                            <input type="text" name="publisher_input" value="" class="standard_tile_input_small_site" id="games_main_pub_input">
-                            <input type="hidden" value="publisher" id="autocomplete2">
+                            <input type="text" name="publisher_input" value="" class="standard_tile_input_small_site autocompleted" id="games_main_pub_input" data-autocomplete-param="publisher">
                         </div>
                     </div>
                     <div class="games_main_row_site">
@@ -332,8 +268,7 @@ The main game page
                                     <option value="{$line.comp_id}">{$line.comp_name}</option>
                                 {/foreach}
                             </select>
-                            <input type="text" name="developer_input" value="" class="standard_tile_input_small_site" id="games_main_dev_input">
-                            <input type="hidden" value="developer" id="autocomplete3">
+                            <input type="text" name="developer_input" value="" class="standard_tile_input_small_site autocompleted" id="games_main_dev_input" data-autocomplete-param="developer">
                         </div>
                     </div>
                     <div class="games_main_row_site">
@@ -346,8 +281,7 @@ The main game page
                                     <option value="{$line.game_year}">{$line.game_year}</option>
                                 {/foreach}
                             </select>
-                            <input type="text" name="year_input" value="" class="standard_tile_input_small_site" id="games_main_year_input">
-                            <input type="hidden" value="year" id="autocomplete4">
+                            <input type="text" name="year_input" value="" class="standard_tile_input_small_site autocompleted" id="games_main_year_input" data-autocomplete-param="year">
                         </div>
                     </div>
                     <div class="games_main_row_site">
@@ -360,8 +294,7 @@ The main game page
                                     <option value="{$line.game_cat_id}">{$line.game_cat_name}</option>
                                 {/foreach}
                             </select>
-                            <input type="text" name="cat_input" value="" class="standard_tile_input_small_site" id="games_main_cat_input">
-                            <input type="hidden" value="cat" id="autocomplete5">
+                            <input type="text" name="cat_input" value="" class="standard_tile_input_small_site autocompleted" id="games_main_cat_input" data-autocomplete-param="cat">
                         </div>
                     </div>
                     <div class="games_main_row_site">

--- a/Website/AtariLegend/themes/templates/1/main/games_main_list.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_main_list.html
@@ -20,148 +20,99 @@ The main game page
 {block name=main_body}
     {literal}
     <script type="text/javascript"> <!-- script needed for the autocompletion search engine -->
-        $(function() {
-            $( "#gamesearch" ).autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete1').val() }, 
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
+        $(document).ready(function() {
+            $(".autocompleted").each(function() {
+                var extraParam = $(this).attr("data-autocomplete-param");
+                $(this).autocomplete({
+                    source: "../../../php/includes/autocomplete.php?extraParams=" + extraParam,
+                    minLength: 2,
+                });
             });
-            
-            $('#games_main_pub_input').autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete2').val() }, 
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
-            });
-            
-            $('#games_main_dev_input').autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete3').val() }, 
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
-            });
-            
-            $('#games_main_year_input').autocomplete({
-                source: function(request, response) {
-                    $.getJSON(
-                        "../../../php/includes/autocomplete.php",
-                        { term:request.term, extraParams:$('#autocomplete4').val() }, 
-                        response
-                    );
-                },
-                minLength: 2,
-                select: function(event, ui){
-                    //On select action
-                }
-            });
-           
         });
     </script>
     {/literal}
     <script type="text/javascript">
-    function dropdown_pub() {      
+    function dropdown_pub() {
         var publisher_input = document.getElementById("games_main_pub_input");
         publisher_input.style.display='none';
-        
+
         var publisher = document.getElementById("games_main_pub_drop");
         publisher.style.display='inline';
-        
+
         var pub_input_text = document.getElementById("input_pub");
         pub_input_text.style.display='none';
-        
+
         var pub_drop_text = document.getElementById("drop_pub");
-        pub_drop_text.style.display='inline';  
+        pub_drop_text.style.display='inline';
     }
-    
-    function input_pub() {      
+
+    function input_pub() {
         var publisher_input = document.getElementById("games_main_pub_input");
         publisher_input.style.display='inline';
-        
+
         var publisher = document.getElementById("games_main_pub_drop");
         publisher.style.display='none';
-        
+
         var pub_input_text = document.getElementById("input_pub");
         pub_input_text.style.display='inline';
-        
+
         var pub_drop_text = document.getElementById("drop_pub");
-        pub_drop_text.style.display='none';  
+        pub_drop_text.style.display='none';
     }
-    
-    function dropdown_dev() {      
+
+    function dropdown_dev() {
         var developer_input = document.getElementById("games_main_dev_input");
         developer_input.style.display='none';
-        
+
         var developer = document.getElementById("games_main_dev_drop");
         developer.style.display='inline';
-        
+
         var dev_input_text = document.getElementById("input_dev");
         dev_input_text.style.display='none';
-        
+
         var dev_drop_text = document.getElementById("drop_dev");
-        dev_drop_text.style.display='inline';  
+        dev_drop_text.style.display='inline';
     }
-    
-    function input_dev() {      
+
+    function input_dev() {
         var developer_input = document.getElementById("games_main_dev_input");
         developer_input.style.display='inline';
-        
+
         var developer = document.getElementById("games_main_dev_drop");
         developer.style.display='none';
-        
+
         var dev_input_text = document.getElementById("input_dev");
         dev_input_text.style.display='inline';
-        
+
         var dev_drop_text = document.getElementById("drop_dev");
-        dev_drop_text.style.display='none';  
+        dev_drop_text.style.display='none';
     }
-    function dropdown_year() {      
+    function dropdown_year() {
         var year_input = document.getElementById("games_main_year_input");
         year_input.style.display='none';
-        
+
         var year = document.getElementById("games_main_year_drop");
         year.style.display='inline';
-        
+
         var year_input_text = document.getElementById("input_year");
         year_input_text.style.display='none';
-        
+
         var year_drop_text = document.getElementById("drop_year");
-        year_drop_text.style.display='inline';  
+        year_drop_text.style.display='inline';
     }
-    
-    function input_year() {      
+
+    function input_year() {
         var year_input = document.getElementById("games_main_year_input");
         year_input.style.display='inline';
-        
+
         var year = document.getElementById("games_main_year_drop");
         year.style.display='none';
-        
+
         var year_input_text = document.getElementById("input_year");
         year_input_text.style.display='inline';
-        
+
         var year_drop_text = document.getElementById("drop_year");
-        year_drop_text.style.display='none';  
+        year_drop_text.style.display='none';
     }
     </script>
     <div id="main" class="main_container_cpanel">
@@ -176,7 +127,7 @@ The main game page
             {if isset($export) and ($export == 'export')}
             <div class="standard_tile" id="games_main">
                 <div class="help-tip">
-                    <p> 
+                    <p>
                        To filter on boxscan, screenshot, download or music, use '1' (=has) or '0' (=has not)
                     </p>
                 </div>
@@ -184,13 +135,13 @@ The main game page
                 <div class="standard_tile_line"></div>
                 <div class="standard_tile_text">
                     <h6>
-                        This is the search result page. Click a game to go to the main page. Click a Publisher/Developer/Year to do a new search. This list has sort functions, filters and you can use the download button to export the contents. 
+                        This is the search result page. Click a game to go to the main page. Click a Publisher/Developer/Year to do a new search. This list has sort functions, filters and you can use the download button to export the contents.
                         For more info regarding this plug in, visit the <a href="https://github.com/olifolkerd/tabulator" class="standard_tile_link_cpanel">Tabulator</a> github page.
                     </h6>
                 </div>
                 <div class="standard_tile_line"></div>
-                <br> 
-                <div class="games_tabulator_list">                
+                <br>
+                <div class="games_tabulator_list">
                     <button id="download-csv" class="export_button">Download CSV</button>
                     <button id="download-json" class="export_button">Download JSON</button>
                     <button id="download-xlsx" class="export_button">Download XLSX</button>
@@ -207,9 +158,9 @@ The main game page
                 <script>
                 //define some sample data
                 var tabledata = {$data};
-               
+
                 {literal}
-                
+
                 //create Tabulator on DOM element with id "example-table"
                 $("#games-table").tabulator({
                     responsiveLayout:true, // this option takes a boolean value (default = false)
@@ -245,23 +196,23 @@ The main game page
 
                 //load sample data into the table
                 $("#games-table").tabulator("setData", tabledata);
-                
+
                 $(window).on('resize', function () {
                     $(".tabulator").tabulator("redraw");
                 });
 
                 {/literal}
-                </script>	
+                </script>
             </div>
             {else}
                 <div class="standard_tile" id="games_main">
                      <div class="help-tip">
-                        <p> 
+                        <p>
                             <i class="fa fa-camera" aria-hidden="true"></i> - Screenshot <br>
                             <i class="fa fa-music" aria-hidden="true"></i> - Music <br>
                             <i class="fa fa-cube" aria-hidden="true"></i> - Boxscan <br>
                             <i class="fa fa-file-o" aria-hidden="true"></i> - Download <br>
-                            <i class="fa fa-newspaper-o" aria-hidden="true"></i> - Review <br> 
+                            <i class="fa fa-newspaper-o" aria-hidden="true"></i> - Review <br>
                         </p>
                     </div>
                     <h1>GAMES</h1>
@@ -272,8 +223,7 @@ The main game page
                             <div class="games_main_text_site_site"><h6>Title</h6></div>
                             <div class="games_main_text_short"><h6>:</h6></div>
                             <div class="games_main_input_site_text">
-                                <input type="text" name="gamesearch" value="" class="standard_tile_input_small_site" id="gamesearch">
-                                <input type="hidden" value="title" id="autocomplete1">
+                                <input type="text" name="gamesearch" value="" class="standard_tile_input_small_site autocompleted" id="gamesearch" data-autocomplete-param="title">
                             </div>
                         </div>
                         <div class="games_main_row_site">
@@ -286,8 +236,7 @@ The main game page
                                         <option value="{$line.comp_id}">{$line.comp_name}</option>
                                     {/foreach}
                                 </select>
-                                <input type="text" name="publisher_input" value="" class="standard_tile_input_small_site" id="games_main_pub_input">
-                                <input type="hidden" value="publisher" id="autocomplete2">
+                                <input type="text" name="publisher_input" value="" class="standard_tile_input_small_site autocompleted" id="games_main_pub_input" data-autocomplete-param="publisher">
                             </div>
                         </div>
                         <div class="games_main_row_site">
@@ -300,8 +249,7 @@ The main game page
                                         <option value="{$line.comp_id}">{$line.comp_name}</option>
                                     {/foreach}
                                 </select>
-                                <input type="text" name="developer_input" value="" class="standard_tile_input_small_site" id="games_main_dev_input">
-                                <input type="hidden" value="developer" id="autocomplete3">
+                                <input type="text" name="developer_input" value="" class="standard_tile_input_small_site autocompleted" id="games_main_dev_input" data-autocomplete-param="developer">
                             </div>
                         </div>
                         <div class="games_main_row_site">
@@ -314,8 +262,7 @@ The main game page
                                         <option value="{$line.game_year}">{$line.game_year}</option>
                                     {/foreach}
                                 </select>
-                                <input type="text" name="year_input" value="" class="standard_tile_input_small_site" id="games_main_year_input">
-                                <input type="hidden" value="year" id="autocomplete4">
+                                <input type="text" name="year_input" value="" class="standard_tile_input_small_site autocompleted" id="games_main_year_input" data-autocomplete-param="year">
                             </div>
                         </div>
                         <div class="standard_table_center">
@@ -323,7 +270,7 @@ The main game page
                             <input type="submit" value="SEARCH" class="quick_search_games_button">
                             <br>
                             <br>
-                        </div>      
+                        </div>
                         <input type="hidden" name="action" id="action" value="search">
                         <input type="hidden" name="mode" id="mode" value="{if isset($mode)}{$mode}{/if}">
                     </form>
@@ -333,11 +280,11 @@ The main game page
                             <tr>
                                 <td colspan="4"><div class="games_main_list_info"><br>{if $nr_of_games == 1}1 game found {else} {$nr_of_games} games found{/if} in {$query_time} sec<br><br></div></td>
                             </tr>
-                            {$tr = true}                             
+                            {$tr = true}
                             {foreach from=$game_search item=line name=game_search}
-                                {if $tr} 
+                                {if $tr}
                                     <tr>
-                                    {$tr = false}    
+                                    {$tr = false}
                                 {/if}
                                     <td style="width:25%;">
                                         {if $line.screenshot_id != ''}
@@ -345,7 +292,7 @@ The main game page
                                                 <a href="games_detail.php?game_id={$line.game_id}">
                                                     <br>
                                                     <img data-original="../../includes/show_image.php?file={$line.screenshot_image}&amp;resize=200,null,null,null" width="200" alt="Click to enlarge!" class="game_main_list_screenshot_img">
-                                                </a>                                           
+                                                </a>
                                             </div>
                                         {/if}
                                         <div class="games_main_list_title">
@@ -355,7 +302,7 @@ The main game page
                                         </div>
                                         <div class="games_main_list_info">
                                             <a href="games_main_list.php?publisher={$line.publisher_id}&amp;action=search" class="standard_table_left">{$line.publisher_name}</a>{if (isset($line.year))}<a href="games_main_list.php?year={$line.year}&amp;action=search" class="standard_table_left">, {$line.year}</a>{/if}
-                                        </div>  
+                                        </div>
                                         <div class="games_main_list_info" style="margin-bottom:10px;">
                                             {if $line.screenshot_id != ''}
                                                 <i class="fa fa-camera" aria-hidden="true" title="More screenshots available"></i>
@@ -371,14 +318,14 @@ The main game page
                                             {/if}
                                             {if isset($line.review)}
                                                 <i class="fa fa-newspaper-o" aria-hidden="true" title="Review available"></i>
-                                            {/if}                                        
+                                            {/if}
                                             {if isset($line.screenshot_id) or isset($line.music) or isset($line.boxscan) or isset($line.download) or isset($line.review)}
                                             {else}
                                                 <br>
                                             {/if}
                                         </div>
                                    </td>
-                                  {if $smarty.foreach.game_search.last} 
+                                  {if $smarty.foreach.game_search.last}
                                       {if $nr_of_games >= 4}
                                         {if $rest4 == 3}
                                             <td>
@@ -400,23 +347,23 @@ The main game page
                                         {/if}
                                       {/if}
                                     {/if}
-                                  {if $smarty.foreach.game_search.iteration is div by 4}       
-                                     </tr> 
-                                     {$tr = true} 
-                                  {/if} 
+                                  {if $smarty.foreach.game_search.iteration is div by 4}
+                                     </tr>
+                                     {$tr = true}
+                                  {/if}
                             {/foreach}
                         </table>
-                    </div>                      
+                    </div>
                     <div id="games_main_list_3">
                         <table class="standard_table_list_comments_main">
                             <tr>
                                 <td colspan="3"><div class="games_main_list_info"><br>{if $nr_of_games == 1}1 game found {else} {$nr_of_games} games found{/if} in {$query_time} sec<br><br></div></td>
                             </tr>
-                            {$tr = true} 
+                            {$tr = true}
                             {foreach from=$game_search item=line name=game_search}
-                                {if $tr} 
+                                {if $tr}
                                     <tr>
-                                    {$tr = false}    
+                                    {$tr = false}
                                 {/if}
                                     <td style="width:25%;">
                                         {if $line.screenshot_id != ''}
@@ -433,7 +380,7 @@ The main game page
                                         </div>
                                         <div class="games_main_list_info">
                                             <a href="games_main_list.php?publisher={$line.publisher_id}&amp;action=search" class="standard_table_left">{$line.publisher_name}</a>{if (isset($line.year))}<a href="games_main_list.php?year={$line.year}&amp;action=search" class="standard_table_left">, {$line.year}</a>{/if}
-                                        </div>  
+                                        </div>
                                         <div class="games_main_list_info" style="margin-bottom:10px;">
                                             {if $line.screenshot_id != ''}
                                                 <i class="fa fa-camera" aria-hidden="true" title="More screenshots available"></i>
@@ -449,44 +396,44 @@ The main game page
                                             {/if}
                                             {if isset($line.review)}
                                                 <i class="fa fa-newspaper-o" aria-hidden="true" title="Review available"></i>
-                                            {/if}                                        
+                                            {/if}
                                             {if isset($line.screenshot_id) or isset($line.music) or isset($line.boxscan) or isset($line.download) or isset($line.review)}
                                             {else}
                                                 <br>
                                             {/if}
                                         </div>
                                    </td>
-                                   {if $smarty.foreach.game_search.last} 
+                                   {if $smarty.foreach.game_search.last}
                                      {if $nr_of_games >= 4}
                                       {if $rest3 == 2}
                                          <td>
                                          </td>
-                                      {/if}   
+                                      {/if}
                                       {if $rest3 == 1}
                                          <td>
                                          </td>
                                          <td>
                                          </td>
-                                      {/if}   
-                                    {/if}  
+                                      {/if}
+                                    {/if}
                                    {/if}
-                                 {if $smarty.foreach.game_search.iteration is div by 3}       
-                                    </tr> 
-                                    {$tr = true} 
-                                 {/if} 
+                                 {if $smarty.foreach.game_search.iteration is div by 3}
+                                    </tr>
+                                    {$tr = true}
+                                 {/if}
                             {/foreach}
                         </table>
-                    </div>           
+                    </div>
                     <div id="games_main_list_2">
                        <table class="standard_table_list_comments_main">
                             <tr>
                                 <td colspan="2"><div class="games_main_list_info"><br>{if $nr_of_games == 1}1 game found {else} {$nr_of_games} games found{/if} in {$query_time} sec<br><br></div></td>
                             </tr>
-                            {$tr = true} 
+                            {$tr = true}
                             {foreach from=$game_search item=line name=game_search}
-                                {if $tr} 
+                                {if $tr}
                                     <tr>
-                                    {$tr = false}    
+                                    {$tr = false}
                                 {/if}
                                     <td style="width:25%;">
                                         {if $line.screenshot_id != ''}
@@ -503,7 +450,7 @@ The main game page
                                         </div>
                                         <div class="games_main_list_info">
                                             <a href="games_main_list.php?publisher={$line.publisher_id}&amp;action=search" class="standard_table_left">{$line.publisher_name}</a>{if (isset($line.year))}<a href="games_main_list.php?year={$line.year}&amp;action=search" class="standard_table_left">, {$line.year}</a>{/if}
-                                        </div>  
+                                        </div>
                                         <div class="games_main_list_info" style="margin-bottom:10px;">
                                             {if $line.screenshot_id != ''}
                                                 <i class="fa fa-camera" aria-hidden="true" title="More screenshots available"></i>
@@ -519,25 +466,25 @@ The main game page
                                             {/if}
                                             {if isset($line.review)}
                                                 <i class="fa fa-newspaper-o" aria-hidden="true" title="Review available"></i>
-                                            {/if}                                        
+                                            {/if}
                                             {if isset($line.screenshot_id) or isset($line.music) or isset($line.boxscan) or isset($line.download) or isset($line.review)}
                                             {else}
                                                 <br>
                                             {/if}
                                         </div>
                                    </td>
-                                   {if $smarty.foreach.game_search.last} 
+                                   {if $smarty.foreach.game_search.last}
                                      {if $nr_of_games >= 3}
                                          {if $rest2 == 1}
                                             <td>
                                             </td>
-                                         {/if} 
+                                         {/if}
                                      {/if}
                                    {/if}
-                                 {if $smarty.foreach.game_search.iteration is div by 2}       
-                                    </tr> 
-                                    {$tr = true} 
-                                 {/if} 
+                                 {if $smarty.foreach.game_search.iteration is div by 2}
+                                    </tr>
+                                    {$tr = true}
+                                 {/if}
                             {/foreach}
                         </table>
                     </div>
@@ -563,7 +510,7 @@ The main game page
                                         </div>
                                         <div class="games_main_list_info">
                                             <a href="games_main_list.php?publisher={$line.publisher_id}&amp;action=search" class="standard_table_left">{$line.publisher_name}</a>{if (isset($line.year))}<a href="games_main_list.php?year={$line.year}&amp;action=search" class="standard_table_left">, {$line.year}</a>{/if}
-                                        </div>  
+                                        </div>
                                         <div class="games_main_list_info" style="margin-bottom:10px;">
                                             {if $line.screenshot_id != ''}
                                                 <i class="fa fa-camera" aria-hidden="true" title="More screenshots available"></i>
@@ -579,14 +526,14 @@ The main game page
                                             {/if}
                                             {if isset($line.review)}
                                                 <i class="fa fa-newspaper-o" aria-hidden="true" title="Review available"></i>
-                                            {/if}                                        
+                                            {/if}
                                             {if isset($line.screenshot_id) or isset($line.music) or isset($line.boxscan) or isset($line.download) or isset($line.review)}
                                             {else}
                                                 <br>
                                             {/if}
                                         </div>
-                                   </td> 
-                                </tr> 
+                                   </td>
+                                </tr>
                             {/foreach}
                         </table>
                     </div>
@@ -609,8 +556,8 @@ The main game page
             <br>
             {block name=right_tile}
                 {include file='1/main/tile_screenstar.html'}
-            {/block}        
+            {/block}
         </div>
     </div>
-    
+
 {/block}

--- a/Website/AtariLegend/themes/templates/1/main/main.html
+++ b/Website/AtariLegend/themes/templates/1/main/main.html
@@ -48,36 +48,18 @@
 		<script type="text/javascript" src="{$template_dir}includes/js/jquery-ui.js"></script> <!-- main jqueryUI stuff -->
         <script type="text/javascript" src="{$template_dir}includes/js/notify-osd.js"></script>
 		<script type="text/javascript"> <!-- script needed for the autocompletion search engine -->
-            $(function() {
-                $( "#auto" ).autocomplete({
-                    source: function(request, response) {
-                        $.getJSON(
-                            "../../../php/includes/autocomplete.php?",
-                            { term:request.term, extraParams: 'title' },
-                            response
-                        );
-                    },
-                    minLength: 2,
-                    select: function(event, ui){
-                        //On select action
-                    }
-                });
+                $(document).ready(function() {
+                    $( "#auto" ).autocomplete({
+                        source: "../../../php/includes/autocomplete.php?extraParams=title",
+                        minLength: 2,
+                    });
 
-                $( "#search_text_side" ).autocomplete({
-                    source: function(request, response) {
-                        $.getJSON(
-                            "../../../php/includes/autocomplete.php?",
-                            { term:request.term, extraParams: 'title' },
-                            response
-                        );
-                    },
-                    minLength: 2,
-                    position: { my : "left top", at: "right top", of: $("#skin_side"), collision: "flipfit none" },
-                    select: function(event, ui){
-                        //On select action
-                    }
+                    $( "#search_text_side" ).autocomplete({
+                        source: "../../../php/includes/autocomplete.php?extraParams=title",
+                        minLength: 2,
+                        position: { my : "left top", at: "right top", of: $("#skin_side"), collision: "flipfit none" },
+                    });
                 });
-            });
 
 			$(document).ready(function()
 			{


### PR DESCRIPTION
Rather than having to declare each autocomplete function for each
individual input field (title, publisher, year, ...), implement it in a
generic way:
* Autocomplete will apply to any field which has an `autocompleted`
class
* The value to pass in the Ajax request for `&extraParams=...` is read
directly from the `data-autocomplete-param` attribute on the
autocompleted input

Thus, an autocompleted input looks like:

`<input class="autocompleted" data-autocompleted-param="publisher">`

Benefits:
* Less code, meaning less bugs and less maintenance :v:
* Adding a new autocompleted field is easier as it's just a matter of
adding an HTML input tag without touching the Javascript

Also simplified the code a bit on the main page auto-complete since
there was a less verbose way to configure the jQuery plugin.

Aside: Fixed a minor CSS issue on the mobile side menu following my
previous change on the search input button.