### PR TITLE
Work for #311: Setup Google Analytics tracking tags

### DIFF
--- a/Website/AtariLegend/php/config/config.php
+++ b/Website/AtariLegend/php/config/config.php
@@ -28,7 +28,8 @@ error_reporting(-1);
 define("SITESTATUS", "online");
 
 // This is the url of the site
-define("SITEURL", "http://www.atarilegend.com/");
+define("SITEHOST", "www.atarilegend.com");
+define("SITEURL", "http://".SITEHOST."/");
 
 //***************************************************************
 // Setup the Smarty Templating framework

--- a/Website/AtariLegend/themes/templates/1/admin/main.html
+++ b/Website/AtariLegend/themes/templates/1/admin/main.html
@@ -134,7 +134,11 @@
                 $('html, body').animate({scrollTop: offsetTop}, 500, 'linear');
             }
         </script>
+        {/literal}
 
+        {* Insert Google Analytics tags only on production *}
+        {if $smarty.server.HTTP_HOST == $smarty.const.SITEHOST}
+        {literal}
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="//www.googletagmanager.com/gtag/js?id=UA-108399799-2"></script>
         <script>
@@ -145,6 +149,8 @@
           gtag('config', 'UA-108399799-2');
         </script>
         {/literal}
+        {/if}
+
         {block name=java_script}{/block}
     </head>
     <body id="body">

--- a/Website/AtariLegend/themes/templates/1/main/main.html
+++ b/Website/AtariLegend/themes/templates/1/main/main.html
@@ -151,7 +151,11 @@
                 }, 500, 'linear');
             }
         </script>
-
+        {/literal}
+ 
+        {* Insert Google Analytics tags only on production *}
+        {if $smarty.server.HTTP_HOST == $smarty.const.SITEHOST}
+        {literal}
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="//www.googletagmanager.com/gtag/js?id=UA-108399799-1"></script>
         <script>
@@ -162,6 +166,8 @@
           gtag('config', 'UA-108399799-1');
         </script>
         {/literal}
+        {/if}
+
 		{block name=javascript_slider} {/block}
 	</head>
 	<body id="body">


### PR DESCRIPTION
I've used 2 different tracking tags for the main website vs. cpanel, so
that we will get separate Analytics reports.

Note that the dev server will also use the same tags so any traffic on
the dev server will be counted the same as traffic on the production
server. I don't think that's a big issue (assuming dev traffic is
insignificant), but if it becomes one we can add some code to only
output the tags on the production URL.  I'd prefer if we started simple
though and see how it goes.