### PR TITLE
Make the ENTER key work on the login form

### DIFF
--- a/Website/AtariLegend/themes/templates/1/admin/main.html
+++ b/Website/AtariLegend/themes/templates/1/admin/main.html
@@ -316,20 +316,17 @@
                           </a>
                           <div id="login-content">                    
                             {if ! isset($user_session.userid)}
-                                <form action="../../common/login/user_process_login.php" method="post" name="login_form">
+                                <form action="../../common/login/user_process_login.php" method="post" name="login_form" onsubmit="formhash(this, this.password);">
                                 <fieldset>
                                     <input class="standard_tile_input_small" type="text" name="userid" placeholder="Username" required>   
                                     <input class="standard_tile_input_small" type="password" name="password" placeholder="Password" required>
-                                    <br><br>                               
-                                    <button type="button" value="Login" class="topbutton_cpanel_small" onclick="formhash(this.form, this.form.password);">
-                                        Sign in
-                                    </button>
-                                    <br><br>
                                     <div class="links_mod_checkbox">
                                         <input type="checkbox" id="remember_me" name="remember_me" value="1">
                                         <label for="remember_me"></label>&nbsp;Remember me
                                     </div>
-                                    <br>
+                                    <br>                               
+                                    <input type="submit" value="Sign in" class="topbutton_cpanel_small">
+                                    <br><br>
                                     <span class="log_on_text"><a href="../../main/front/front.php?action=reset" class="standard_tile_link_black"><i class="fa fa-angle-double-right" aria-hidden="true"></i>&nbsp;Forgot password?</a></span>
                                     <br>
                                     <span class="log_on_text"><a href="../../main/front/front.php?action=register" class="standard_tile_link_black"><i class="fa fa-angle-double-right" aria-hidden="true"></i>&nbsp;No account? Sign up now <i class="fa fa-chevron-right" aria-hidden="true"></i></a></span>

--- a/Website/AtariLegend/themes/templates/1/includes/js/forms.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/forms.js
@@ -19,9 +19,6 @@ function formhash(form, password) {
 
     // Make sure the plaintext password doesn't get sent. 
     password.value = "";
- 
-    // Finally submit the form. 
-    form.submit();
 }
  
 function regformhash(form, uid, email, password, conf) {

--- a/Website/AtariLegend/themes/templates/1/main/main.html
+++ b/Website/AtariLegend/themes/templates/1/main/main.html
@@ -237,20 +237,17 @@
                           </a>
                           <div id="login-content">
                             {if ! isset($user_session.userid)}
-                                <form action="../../common/login/user_process_login.php" method="post" name="login_form">
+                                <form action="../../common/login/user_process_login.php" method="post" name="login_form" onsubmit="formhash(this, this.password);">
                                 <fieldset>
                                     <input class="standard_tile_input_small" type="text" name="userid" placeholder="Username" required>
                                     <input class="standard_tile_input_small" type="password" name="password" placeholder="Password" required>
-                                    <br><br>
-                                    <button type="button" value="Login" class="topbutton_cpanel_small" onclick="formhash(this.form, this.form.password);">
-                                        Sign in
-                                    </button>
-                                    <br><br>
                                     <div class="links_mod_checkbox">
                                         <input type="checkbox" id="remember_me" name="remember_me" value="1">
                                         <label for="remember_me"></label>&nbsp;Remember me
                                     </div>
                                     <br>
+                                    <input type="submit" value="Sign in" class="topbutton_cpanel_small">
+                                    <br><br>
                                     <span class="log_on_text"><a href="../../main/front/front.php?action=reset" class="standard_tile_link_black"><i class="fa fa-angle-double-right" aria-hidden="true"></i>&nbsp;Forgot password?</a></span>
                                     <br>
                                     <span class="log_on_text"><a href="../../main/front/front.php?action=register" class="standard_tile_link_black"><i class="fa fa-angle-double-right" aria-hidden="true"></i>&nbsp;No account? Sign up now <i class="fa fa-chevron-right" aria-hidden="true"></i></a></span>


### PR DESCRIPTION
The ENTER key didn't work on the login form because the submit button
was not a `<input type="submit">` but a `<button>`. Changed it, and
moved the password hash function on the form `onsubmit` action.

I also moved the "Remember me" checkbox just after the password rather
than after the "Sign in" button. I think that's how it's done usually,
and it has the benefit of being able to easily and quickly log in via
keyboard only:
* Type your username, then TAB to go to the password
* Type your password, then TAB to go to the "Remember me" checkbox
* Tick the checkbox with SPACE
* Hit ENTER to log in