### PR TITLE
Main front page

### DIFF
--- a/Website/AtariLegend/themes/templates/1/main/main.html
+++ b/Website/AtariLegend/themes/templates/1/main/main.html
@@ -87,7 +87,7 @@
 					});
 			});
 
-        <!-- script needed for the side menu -->
+            <!-- script needed for the side menu -->
 			//<![CDATA[
 			$(window).load(function(){
 			  $("[data-toggle]").click(function() {
@@ -173,7 +173,7 @@
                                         <li><a href="../../admin/" class="sidebutton" id="cpanel_side">CPANEL</a></li>
                                         <li><a href="http://www.atari-forum.com" class="sidebutton" id="forum_main_side">FORUM</a></li>
                                         <li><a href="../classAL/classAL.php" class="sidebutton" id="about_side">ABOUT</a></li>
-                                        </ul>
+                                    </ul>
                                 </nav>
                             </div>
                             <form action="../games/games_main_list.php" method="get">


### PR DESCRIPTION
- One css link had double type attributes
- Also noted that "literal" was being used which since smarty3 shouldn't be necessary. Fix was simple enough, added a space between function() and {