### PR TITLE
Fixes #250 again: redirection on POST

### DIFF
--- a/Website/AtariLegend/.htaccess
+++ b/Website/AtariLegend/.htaccess
@@ -14,8 +14,9 @@ RewriteBase /
 # to /games/games_details.php?game_id=...
 
 # If request are coming for /php/something.php, redirect them to /something.php
+# Use 307 and not 301 to cover POST redirection (See issue #250)
 RewriteCond %{THE_REQUEST} ^[A-Z]{3,}\s/+php/([^\s]+) [NC]
-RewriteRule ^ %1 [R=301,L]
+RewriteRule ^ %1 [R=307,L]
 
 # If the requested folder or file doesn't exist, look it up under php/
 # For example if the request is /main/front/front.php, look it up

--- a/Website/AtariLegend/php/.htaccess
+++ b/Website/AtariLegend/php/.htaccess
@@ -7,12 +7,14 @@ RewriteBase /
 # /php/ and /php/main/ folders
 
 # If request are coming for /php/something.php, redirect them to /something.php
+# Use 307 and not 301 to cover POST redirection (See issue #250)
 RewriteCond %{THE_REQUEST} ^[A-Z]{3,}\s/+php/([^\s]+) [NC]
-RewriteRule ^ %1 [R=301,L]
+RewriteRule ^ %1 [R=307,L]
 
 # If request are coming for /main/something.php, redirect them to /something.php
+# Use 307 and not 301 to cover POST redirection (See issue #250)
 RewriteCond %{THE_REQUEST} ^[A-Z]{3,}\s/+main/([^\s]+) [NC]
-RewriteRule ^ %1 [R=301,L]
+RewriteRule ^ %1 [R=307,L]
 
 # If the requested folder or file doesn't exist, look it up under main/
 # For example if the request is /front/front.php, look it up


### PR DESCRIPTION
Use a 307 redirect code instead of 301 so that POST data will be carried
over by the browser on redirection, which is not the case with 301.

This is especially needed on the games details page where users can
submit information about a game. The form URL is something like
`action="../../main/games/..."`, causing a rewrite to be triggered to
remove the `/main/` part.