### PR TITLE
Added fallback front when Verdana is not available

### DIFF
--- a/Sources/styles/1/scss/_general.scss
+++ b/Sources/styles/1/scss/_general.scss
@@ -31,8 +31,7 @@ html {
 }
 
 body{
-    /* font-family: -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI","Roboto","Helvetica Neue", Arial, sans-serif; */
-    font-family: verdana;
+    font-family: verdana, Arial, Helvetica, sans-serif;
     background-color: #000;
 }
 


### PR DESCRIPTION
Verdana may not be available on all systems: Linux for sure, perhaps Mac
OS too? In that case, added some fallback font to avoid the default
Times New Roman.