### PR TITLE
Added a rewrite rule for the old interview URLs

### DIFF
--- a/Website/AtariLegend/.htaccess
+++ b/Website/AtariLegend/.htaccess
@@ -7,6 +7,12 @@ ErrorDocument 404 /themes/templates/1/page_not_found.html
 RewriteEngine On
 RewriteBase /
 
+# Rewrite old interviews URLs to the new structure, as multiple websites are
+# still linking to the old URLs. e.g.:
+# /interviews/interview.php?interview_id=4 -> /interviews/interviews_detail.php?selected_interview_id=4
+RewriteCond %{QUERY_STRING} "interview_id=([0-9]+)"
+RewriteRule "^interviews/interview\.php" "interviews/interviews_detail.php?selected_interview_id=%1" [R=301,L]
+
 # The following rules are to hide the root level /php/ and /php/main/
 # folders from the URL. We want to simulate users accessing files under these
 # folders as if they were are the root / of the website.


### PR DESCRIPTION
The Google Search Console reported that some external sites were linking
to us on an invalid URL, because they were linking interviews and the
URL to an interview has changed with the latest version of AtariLegend.

To mitigate this, add a redirection so that old URLs will continue
working, to avoid breaking links from external websites.

Example of sites linking our interviews:
* https://notes.variogr.am/page/5/
* http://www.classicarcadegaming.com/forums/index.php?topic=1089.5;wap2
* http://www.8bitrocket.com/2008/05/19/atari-history-125-atari-interviews-on-the-web/
* http://www.retrogamingtimes.com/rtm62/
* http://www.bytecellar.com/2004/10/26/time_bandit/