### PR TITLE
Generate sitemaps for Google to index all of our content

### DIFF
--- a/Website/AtariLegend/php/config/config.php
+++ b/Website/AtariLegend/php/config/config.php
@@ -31,6 +31,11 @@ define("SITESTATUS", "online");
 define("SITEHOST", "www.atarilegend.com");
 define("SITEURL", "http://".SITEHOST."/");
 
+// The URL of the site as requested in the browser, without a trailing slash
+// Useful to generate absolute URLs that will work both
+// for 'localhost', 'dev.stonish.net' and 'www.atarilegend.com'
+define("REQUEST_SITEURL", $_SERVER["REQUEST_SCHEME"]."://".$_SERVER["HTTP_HOST"]);
+
 //***************************************************************
 // Setup the Smarty Templating framework
 //***************************************************************

--- a/Website/AtariLegend/php/main/front/sitemap_games.php
+++ b/Website/AtariLegend/php/main/front/sitemap_games.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Generate a sitemap for games starting with a given letter
+ *
+ * This generates a sitemap providing links to each individual games starting
+ * with a specific letter or number
+ *
+ * In addition, the special value '-' generates a list of all game that start
+ * with anything else than a letter or number (e.g. 'EE's Lost His Marbles)
+ */
+
+require("../../config/common.php");
+
+// Letter parameter is mandatory, and must only have one character
+// which is a letter, number or '-'
+if (! isset($letter) || !preg_match("/^[a-z0-9-]$/i", $letter)) {
+	http_response_code(400);
+	exit();
+}
+
+if ($letter == "-") {
+	// Special case: Select all games that don't start with a letter or number
+	$stmt = $mysqli->prepare("SELECT game_id FROM game WHERE LOWER(game_name) NOT REGEXP('^[a-zA-Z0-9]') ORDER BY game_id")
+		or die($mysqli->error);
+} else {
+	// Select all games stating with the given letter or number
+	$stmt = $mysqli->prepare("SELECT game_id FROM game WHERE LOWER(game_name) LIKE CONCAT(LOWER(?), '%') ORDER BY game_id")
+		or die($mysqli->error);
+	$stmt->bind_param("s", $letter)
+		or die($mysqli->error);
+}
+
+$stmt->execute() or die($mysqli->error);
+$stmt->bind_result($game_id) or die($mysqli->error);
+
+// Fetch all game ids for the letter
+$game_ids = [];
+while ($stmt->fetch()) {
+	$game_ids[] = $game_id;
+}
+
+$stmt->close();
+
+header("Content-Type: application/xml");
+
+$smarty->assign("game_ids", $game_ids);
+$smarty->display("file:${mainsite_template_folder}sitemap_games.xml");

--- a/Website/AtariLegend/php/main/front/sitemap_general.php
+++ b/Website/AtariLegend/php/main/front/sitemap_general.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Generate the general sitemap for all content pages except the games
+ */
+
+require("../../config/common.php");
+
+// Retrieve all interview ids
+$stmt = $mysqli->prepare("SELECT interview_id FROM interview_main ORDER BY interview_id")
+	or die($mysqli->error);
+$stmt->execute() or die($mysqli->error);
+$stmt->bind_result($interview_id) or die($mysqli->error);
+
+$interview_ids = [];
+while ($stmt->fetch()) {
+	$interview_ids[] = $interview_id;
+}
+$stmt->close();
+$smarty->assign("interview_ids", $interview_ids);
+
+// Retrieve all review ids
+$stmt = $mysqli->prepare("SELECT review_id FROM review_main ORDER BY review_id")
+	or die($mysqli->error);
+$stmt->execute() or die($mysqli->error);
+$stmt->bind_result($review_id) or die($mysqli->error);
+
+$review_ids = [];
+while ($stmt->fetch()) {
+	$review_ids[] = $review_id;
+}
+$stmt->close();
+$smarty->assign("review_ids", $review_ids);
+
+header("Content-Type: application/xml");
+
+$smarty->display("file:${mainsite_template_folder}sitemap_general.xml");

--- a/Website/AtariLegend/php/main/front/sitemap_index.php
+++ b/Website/AtariLegend/php/main/front/sitemap_index.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Generate a sitemap index files
+ *
+ * This generates a sitemap index file, splitting the games into sub-sitemaps
+ * (1 per letter of the alphabet)
+ */
+
+require("../../config/common.php");
+
+header("Content-Type: application/xml");
+
+$smarty->assign("range", array_merge(range(0, 9), range("a", "z")));
+$smarty->display("file:${mainsite_template_folder}sitemap_index.xml");

--- a/Website/AtariLegend/robots.txt
+++ b/Website/AtariLegend/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /admin/
+
+Sitemap: http://www.atarilegend.com/front/sitemap_index.php

--- a/Website/AtariLegend/themes/templates/1/main/sitemap_games.xml
+++ b/Website/AtariLegend/themes/templates/1/main/sitemap_games.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{foreach from=$game_ids item=id}
+	<url>
+		<loc>{$smarty.const.REQUEST_SITEURL}/games/games_detail.php?game_id={$id}</loc>
+		<changefreq>weekly</changefreq>
+	</url>
+{/foreach}
+</urlset> 

--- a/Website/AtariLegend/themes/templates/1/main/sitemap_general.xml
+++ b/Website/AtariLegend/themes/templates/1/main/sitemap_general.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	<url>
+		<loc>{$smarty.const.REQUEST_SITEURL}/</loc>
+		<changefreq>daily</changefreq>
+	</url>
+	<url>
+		<loc>{$smarty.const.REQUEST_SITEURL}/news/news.php</loc>
+		<changefreq>daily</changefreq>
+	</url>
+{foreach from=$interview_ids item=id}
+	<url>
+		<loc>{$smarty.const.REQUEST_SITEURL}/interviews/interviews_detail.php?selected_interview_id={$id}</loc>
+		<changefreq>monthly</changefreq>
+	</url>
+{/foreach}
+{foreach from=$review_ids item=id}
+	<url>
+		<loc>{$smarty.const.REQUEST_SITEURL}/games/games_reviews_detail.php?review_id={$id}</loc>
+		<changefreq>monthly</changefreq>
+	</url>
+{/foreach}
+</urlset> 
+

--- a/Website/AtariLegend/themes/templates/1/main/sitemap_index.xml
+++ b/Website/AtariLegend/themes/templates/1/main/sitemap_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	<sitemap>
+		<loc>{$smarty.const.REQUEST_SITEURL}/front/sitemap_general.php</loc>
+	</sitemap>
+	<sitemap>
+		<loc>{$smarty.const.REQUEST_SITEURL}/front/sitemap_games.php?letter=-</loc>
+	</sitemap>
+{foreach from=$range item=item}
+	<sitemap>
+		<loc>{$smarty.const.REQUEST_SITEURL}/front/sitemap_games.php?letter={$item}</loc>
+	</sitemap>
+{/foreach}
+</sitemapindex>


### PR DESCRIPTION
Google seems to be missing some content that we offer, for example as of
yesterday it had only crawled 750 pages where it should have been a lot
more (since we have a lot more games that each have their individual
page).

To assist Google, and following their recommendations, generate
[Sitemaps](https://support.google.com/webmasters/answer/156184?hl=en)
that list all the content that need to be indexed. Where it makes sense,
also give a hint of how often the content is updated so that Google can
re-fetch it on the right schedule (rather than hammering us every day
with crawl requests).

So:
* Added a `robots.txt` to give the location of the sitemap. Also prevent
`/admin/` to be indexed, it shouldn't happen as it require
authentication but it doesn't hurt to specify it
* Generate a "sitemap index" to break down our sitemaps in multiple
files
* Generate a general sitemap containing some of the pages (e.g. News) as
well as all the interviews, and reviews page
* Generate one sitemap file per game, one for each letter of the
alphabet, 0-9 and special characters

I added a new constant `REQUEST_SITEURL` containing the actual URL used
to access the site (e.g. `localhost` on development, `dev.stonish.net`
on dev, etc.) to be able to test things: Sitemaps must contain absolute
URLs, and I couldn't test it if I hardcoded it to www.atarilegend.com.