### PR TITLE
Fixes #358: Adding games with apostrophes in the name

### DIFF
--- a/Website/AtariLegend/php/admin/games/db_games_detail.php
+++ b/Website/AtariLegend/php/admin/games/db_games_detail.php
@@ -29,7 +29,10 @@ include("../../config/admin_rights.php");
 //***********************************************************************************
 if (isset($action) and $action == "insert_game") {
     //Insert the game in the game table
-    $sql_game = $mysqli->query("INSERT INTO game (game_name) VALUES ('$newgame')") or die("Couldn't insert game into database");
+    $stmt = $mysqli->prepare("INSERT INTO game (game_name) VALUES (?)") or die($mysqli->error);
+    $stmt->bind_param("s", $newgame) or die($mysqli->error);
+    $stmt->execute() or die($mysqli->error);
+    $stmt->close();
 
     $_SESSION['edit_message'] = "The game $newgame has been inserted into the database";
 

--- a/Website/AtariLegend/themes/templates/1/admin/games_main.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_main.html
@@ -19,34 +19,6 @@ The main game page
 ************************************************************************************************
 *}
 {extends file='1/admin/frontpage.html'}
-{block name=java_script}
-<script type="text/javascript">
-function gameinsert_gm()
-{
-    JSnewgame=document.getElementById("gm_newgame").value;
-
-	if (JSnewgame=='')
-	{
-		alert('Please fill in a game name');
-	}
-	else
-	{
-    	// CONFIRM REQUIRES ONE ARGUMENT
-    	var message = "Are you sure you want to insert this game into the database?";
-    	// CONFIRM IS BOOLEAN. THAT MEANS THAT
-    	// IT RETURNS TRUE IF 'OK' IS CLICKED
-    	// OTHERWISE IT RETURN FALSE
-    	var return_value = confirm(message);
-
-    	if (return_value !="0")
-    	{
-    		url="db_games_detail.php?newgame="+JSnewgame+"&action=insert_game";
-			location.href=url;
-    	}
-	}
-}
-</script>
-{/block}
 
 {block name=left_tile}
     {include file='1/admin/left_nav.html'}
@@ -255,12 +227,13 @@ function gameinsert_gm()
 		</form>
 		<br>
 		<br>
-		<form method="post" name="insertgame">
+		<form method="post" action="db_games_detail.php" name="insertgame" onsubmit="return confirm('Are you sure you want to insert this game into the database?');">
+		<input type="hidden" name="action" value="insert_game">
 		<fieldset>
 		<legend>Add games</legend>
 			<div class="standard_table_center">
-				<input type="text" name="newgame" id="gm_newgame" value="" class="standard_tile_input_small">
-				<input type="submit" value="Insert" onClick="gameinsert_gm(); return false;" class="topbutton_cpanel_small">
+				<input type="text" name="newgame" id="gm_newgame" required class="standard_tile_input_small">
+				<input type="submit" value="Insert" class="topbutton_cpanel_small">
 			</div>
 		</fieldset>
 		</form>


### PR DESCRIPTION
It failed because the SQL query was not constructed with a prepared
statement, so the apostrophe would be interpreted as the closing of a
SQL quote rather than being part of the value. That bug illustrates well
why we should prefer prepared statements everywhere :wink:

Also simplified the Javascript:
* There's no need to check the value of the field, if we mark it
`required` the browser will do that for us and prevent form submission
if the field is empty
* No need too to redirect the user to a new URL, we can just use the
form `action` for that
* Finally the confirmation message can be in-line directly in the form
`onsubmit`