### PR TITLE
Downgrade Docker PHP version to 5.6, same as dev & prod environment

### DIFF
--- a/Docker/php/Dockerfile
+++ b/Docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-apache
+FROM php:5.6-apache
 
 RUN apt-get update -y
 RUN apt-get install -y libpng-dev

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ an update/upgrade :wink:
 
 # Local installation
 
+Follow the instructions below to setup your local environment. Alternatively,
+use the [pre-configured Docker setup](Docker/README.md).
+
 ## Prerequisites
 
 * A web server with PHP, with the `mysqli` and `gd` extensions (Require PNG and JPEG support)


### PR DESCRIPTION
This is to avoid using features from more recent PHP versions that
wouldn't work on production. It will also ensure Shippable runs the
tests and code with the same version.

Aside: Updated main README to point to the Docker instructions.