### PR TITLE
Configure ESLint to check for Javascript issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,15 @@
+{
+    "extends": "standard",
+    "rules": {
+        "semi": ["off", "always"],
+        "indent": ["error", 4],
+        "one-var": ["off"]
+    },
+    "env": {
+        "browser": true,
+        "jquery": true
+    },
+    "globals": {
+        "Tabulator": true
+    }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,145 +1,161 @@
-module.exports = function(grunt) {
+module.exports = function (grunt) {
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        webRoot: 'Website/AtariLegend/',
 
-  // Project configuration.
-  grunt.initConfig({
-    pkg: grunt.file.readJSON('package.json'),
-    sass: {
-        options: {
-            sourceMap: true
+        sass: {
+            options: {
+                sourceMap: true
             },
             dist: {
                 files: {
-                    'Website/AtariLegend/themes/styles/1/css/style.css': 'Sources/styles/1/scss/style.scss'
+                    '<%= webRoot %>themes/styles/1/css/style.css': 'Sources/styles/1/scss/style.scss'
                 }
             },
             dist2: {
                 files: {
-                    'Website/AtariLegend/themes/styles/2/css/style.css': 'Sources/styles/2/scss/style.scss'
+                    '<%= webRoot %>themes/styles/2/css/style.css': 'Sources/styles/2/scss/style.scss'
                 }
             },
             dist3: {
                 files: {
-                    'Website/AtariLegend/themes/styles/3/css/style.css': 'Sources/styles/3/scss/style.scss'
+                    '<%= webRoot %>themes/styles/3/css/style.css': 'Sources/styles/3/scss/style.scss'
                 }
             }
         },
 
-    scsslint: {
-        allFiles: [
-            'Sources/styles/1/scss/*.scss',
-            'Sources/styles/2/scss/*.scss',
-            'Sources/styles/3/scss/*.scss',
-            'Sources/styles/common/main_scss/**/*.scss',
-        ],
-        options: {
-            bundleExec: false,
-            config: '.scss-lint.yml',
-            reporterOutput: 'result/scss-lint-report.xml',
-            colorizeOutput: true,
-            SelectorFormat: 'snake_case',
-            maxBuffer: 3000000 * 1024
+        eslint: {
+            application: {
+                src: [
+                    'Gruntfile.js',
+                    '<%= webRoot %>/themes/templates/1/includes/js/*.js',
+                    // For now ignore some files that need cleanup
+                    '!<%= webRoot %>/themes/templates/1/includes/js/bbcode.js',
+                    '!<%= webRoot %>/themes/templates/1/includes/js/forms.js',
+                    '!<%= webRoot %>/themes/templates/1/includes/js/menus.js'
+                ]
+            },
+            needsCleanup: {
+                src: [
+                    // Specific target to run manually to work on cleaning up these
+                    '<%= webRoot %>/themes/templates/1/includes/js/bbcode.js',
+                    '<%= webRoot %>/themes/templates/1/includes/js/forms.js',
+                    '<%= webRoot %>/themes/templates/1/includes/js/menus.js'
+                ]
+            }
         },
-    },
 
-    sasslint: {
-        options: {
-            configFile: '.sass-lint.yml',
-            formatter: 'stylish'
+        scsslint: {
+            allFiles: [
+                'Sources/styles/1/scss/*.scss',
+                'Sources/styles/2/scss/*.scss',
+                'Sources/styles/3/scss/*.scss',
+                'Sources/styles/common/main_scss/**/*.scss'
+            ],
+            options: {
+                bundleExec: false,
+                config: '.scss-lint.yml',
+                reporterOutput: 'result/scss-lint-report.xml',
+                colorizeOutput: true,
+                SelectorFormat: 'snake_case',
+                maxBuffer: 3000000 * 1024
+            }
         },
-        target: [
-            'Sources/styles/1/scss/*.scss',
-            'Sources/styles/2/scss/*.scss',
-            'Sources/styles/3/scss/*.scss',
-            'Sources/styles/common/main_scss/**/*.scss',
-        ]
-    },
 
-
-  pleeease: {
-    custom: {
-      options: {
-        autoprefixer: {'browsers': ['last 4 versions', 'ios 6']},
-        filters: {'oldIE': true},
-        rem: ['12px'],
-        opacity: true,
-        minifier: true,
-        mqpacker: false,
-        pseudoElements: true,
-      },
-      files: {
-        'Website/AtariLegend/themes/styles/1/css/style.css': 'Website/AtariLegend/themes/styles/1/css/style.css',
-        'Website/AtariLegend/themes/styles/2/css/style.css': 'Website/AtariLegend/themes/styles/2/css/style.css',
-        'Website/AtariLegend/themes/styles/3/css/style.css': 'Website/AtariLegend/themes/styles/3/css/style.css'
-      }
-    }
-  },
-
-    watch: {
-      sass: {
-        files: [
-            'Sources/styles/1/scss/*.scss',
-            'Sources/styles/2/scss/*.scss',
-            'Sources/styles/3/scss/*.scss',
-            'Sources/styles/common/main_scss/**/*.scss'
-        ],
-        tasks: ['default']
-      },
-    },
-
-    phpcs: {
-    application: {
-        src: [
-                //'Website/AtariLegend/php/admin/menus/ajax_adddocs_menus.php',
-                'Website/AtariLegend/php/main/**/*.php'
-        ]
-    },
-    options: {
-        bin: '/usr/bin/phpcs -d memory_limit=128M',
-        standard: 'PSR2',
-        reportFile: 'result/report.txt',
-        verbose: true,
-        maxBuffer: 10000000000*2048,
-    }
-    },
-
-  stylizeSCSS: {
-    target: {
-      options: {
-            tabSize: 4,
-            extraLine: true,
-            oneLine: true,
-            cleanZeros: true
-      },
-
-      files: [{
-        expand: true,
-        src: [
-            'Sources/styles/1/scss/*.scss',
-            'Sources/styles/2/scss/*.scss',
-            'Sources/styles/3/scss/*.scss',
-            'Sources/styles/common/main_scss/**/*.scss'
-        ],
-        dest: 'result/scss/'
-      }]
-    },
-
-},
-    stylefmt: {
-    format: {
-        options: {
-            syntax: 'scss'
+        sasslint: {
+            options: {
+                configFile: '.sass-lint.yml',
+                formatter: 'stylish'
+            },
+            target: [
+                'Sources/styles/1/scss/*.scss',
+                'Sources/styles/2/scss/*.scss',
+                'Sources/styles/3/scss/*.scss',
+                'Sources/styles/common/main_scss/**/*.scss'
+            ]
         },
-        files: {
-             'result/fix/scss/': ['Sources/styles/1/scss/*.scss']
-      }
-    },
-  },
 
+        pleeease: {
+            custom: {
+                options: {
+                    autoprefixer: {'browsers': ['last 4 versions', 'ios 6']},
+                    filters: {'oldIE': true},
+                    rem: ['12px'],
+                    opacity: true,
+                    minifier: true,
+                    mqpacker: false,
+                    pseudoElements: true
+                },
+                files: {
+                    '<%= webRoot %>themes/styles/1/css/style.css': '<%= webRoot %>themes/styles/1/css/style.css',
+                    '<%= webRoot %>themes/styles/2/css/style.css': '<%= webRoot %>themes/styles/2/css/style.css',
+                    '<%= webRoot %>themes/styles/3/css/style.css': '<%= webRoot %>themes/styles/3/css/style.css'
+                }
+            }
+        },
+
+        watch: {
+            sass: {
+                files: [
+                    'Sources/styles/1/scss/*.scss',
+                    'Sources/styles/2/scss/*.scss',
+                    'Sources/styles/3/scss/*.scss',
+                    'Sources/styles/common/main_scss/**/*.scss'
+                ],
+                tasks: ['default']
+            }
+        },
+
+        phpcs: {
+            application: {
+                src: [
+                    // '<%= webRoot %>php/admin/menus/ajax_adddocs_menus.php',
+                    '<%= webRoot %>php/main/**/*.php'
+                ]
+            },
+            options: {
+                standard: 'PSR2'
+            }
+        },
+
+        stylizeSCSS: {
+            target: {
+                options: {
+                    tabSize: 4,
+                    extraLine: true,
+                    oneLine: true,
+                    cleanZeros: true
+                },
+
+                files: [{
+                    expand: true,
+                    src: [
+                        'Sources/styles/1/scss/*.scss',
+                        'Sources/styles/2/scss/*.scss',
+                        'Sources/styles/3/scss/*.scss',
+                        'Sources/styles/common/main_scss/**/*.scss'
+                    ],
+                    dest: 'result/scss/'
+                }]
+            }
+
+        },
+        stylefmt: {
+            format: {
+                options: {
+                    syntax: 'scss'
+                },
+                files: {
+                    'result/fix/scss/': ['Sources/styles/1/scss/*.scss']
+                }
+            }
+        }
 
     });
 
     // Load the plugin that provides the "uglify" task.
-    //grunt.loadNpmTasks('grunt-contrib-uglify');
+    // grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-sass');
     grunt.loadNpmTasks('grunt-scss-lint');
     grunt.loadNpmTasks('grunt-scss-stylize');
@@ -149,9 +165,10 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-sass-lint');
     grunt.loadNpmTasks('grunt-stylefmt');
     grunt.loadNpmTasks('grunt-stylelint');
+    grunt.loadNpmTasks('grunt-eslint');
 
     // Default task(s).
-    grunt.registerTask('default', ['sass','pleeease']);
+    grunt.registerTask('default', ['eslint:application', 'sass', 'pleeease']);
     grunt.registerTask('lint', ['scsslint']);
     grunt.registerTask('sass-lint', ['sasslint']);
     grunt.registerTask('beauty', ['stylizeSCSS']);

--- a/Website/AtariLegend/themes/templates/1/includes/js/about.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/about.js
@@ -1,26 +1,26 @@
-jQuery(document).ready(function($){
-	var timelineBlocks = $('.cd-timeline-block'),
-		offset = 0.8;
+jQuery(document).ready(function ($) {
+    var timelineBlocks = $('.cd-timeline-block'),
+        offset = 0.8;
 
-	//hide timeline blocks which are outside the viewport
-	hideBlocks(timelineBlocks, offset);
+    // hide timeline blocks which are outside the viewport
+    hideBlocks(timelineBlocks, offset);
 
-	//on scolling, show/animate timeline blocks when enter the viewport
-	$(window).on('scroll', function(){
-		(!window.requestAnimationFrame) 
-			? setTimeout(function(){ showBlocks(timelineBlocks, offset); }, 100)
-			: window.requestAnimationFrame(function(){ showBlocks(timelineBlocks, offset); });
-	});
+    // on scolling, show/animate timeline blocks when enter the viewport
+    $(window).on('scroll', function () {
+        (!window.requestAnimationFrame)
+            ? setTimeout(function () { showBlocks(timelineBlocks, offset); }, 100)
+            : window.requestAnimationFrame(function () { showBlocks(timelineBlocks, offset); });
+    });
 
-	function hideBlocks(blocks, offset) {
-		blocks.each(function(){
-			( $(this).offset().top > $(window).scrollTop()+$(window).height()*offset ) && $(this).find('.cd-timeline-img, .cd-timeline-content').addClass('is-hidden');
-		});
-	}
+    function hideBlocks (blocks, offset) {
+        blocks.each(function () {
+            ($(this).offset().top > $(window).scrollTop() + $(window).height() * offset) && $(this).find('.cd-timeline-img, .cd-timeline-content').addClass('is-hidden');
+        });
+    }
 
-	function showBlocks(blocks, offset) {
-		blocks.each(function(){
-			( $(this).offset().top <= $(window).scrollTop()+$(window).height()*offset && $(this).find('.cd-timeline-img').hasClass('is-hidden') ) && $(this).find('.cd-timeline-img, .cd-timeline-content').removeClass('is-hidden').addClass('bounce-in');
-		});
-	}
+    function showBlocks (blocks, offset) {
+        blocks.each(function () {
+            ($(this).offset().top <= $(window).scrollTop() + $(window).height() * offset && $(this).find('.cd-timeline-img').hasClass('is-hidden')) && $(this).find('.cd-timeline-img, .cd-timeline-content').removeClass('is-hidden').addClass('bounce-in');
+        });
+    }
 });

--- a/Website/AtariLegend/themes/templates/1/includes/js/bbcode.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/bbcode.js
@@ -17,22 +17,21 @@
 var clientPC = navigator.userAgent.toLowerCase(); // Get client info
 var clientVer = parseInt(navigator.appVersion); // Get browser version
 
-var is_ie = ((clientPC.indexOf("msie") != -1) && (clientPC.indexOf("opera") == -1));
-var is_nav = ((clientPC.indexOf('mozilla')!=-1) && (clientPC.indexOf('spoofer')==-1)
-                && (clientPC.indexOf('compatible') == -1) && (clientPC.indexOf('opera')==-1)
-                && (clientPC.indexOf('webtv')==-1) && (clientPC.indexOf('hotjava')==-1));
+var is_ie = ((clientPC.indexOf('msie') != -1) && (clientPC.indexOf('opera') == -1));
+var is_nav = ((clientPC.indexOf('mozilla') != -1) && (clientPC.indexOf('spoofer') == -1) &&
+                (clientPC.indexOf('compatible') == -1) && (clientPC.indexOf('opera') == -1) &&
+                (clientPC.indexOf('webtv') == -1) && (clientPC.indexOf('hotjava') == -1));
 var is_moz = 0;
 
-var is_win = ((clientPC.indexOf("win")!=-1) || (clientPC.indexOf("16bit") != -1));
-var is_mac = (clientPC.indexOf("mac")!=-1);
+var is_win = ((clientPC.indexOf('win') != -1) || (clientPC.indexOf('16bit') != -1));
+var is_mac = (clientPC.indexOf('mac') != -1);
 
 // Define the bbCode tags
-bbtags = new Array('[b]','[/b]','[i]','[/i]','[u]','[/u]','[url=http://www.yourlink.com]','[/url]','[email]','[/email]', '[hotspotUrl=#]', '[/hotspotUrl]', '[hotspot=]', '[/hotspot]','[frontpage]','[/frontpage]');
+bbtags = new Array('[b]', '[/b]', '[i]', '[/i]', '[u]', '[/u]', '[url=http://www.yourlink.com]', '[/url]', '[email]', '[/email]', '[hotspotUrl=#]', '[/hotspotUrl]', '[hotspot=]', '[/hotspot]', '[frontpage]', '[/frontpage]');
 bbcode = new Array();
 imageTag = false;
 
-function bbstyle(bbnumber, bbname) {
-
+function bbstyle (bbnumber, bbname) {
     var txtarea = eval('document.post.' + bbname);
 
     txtarea.focus();
@@ -45,33 +44,30 @@ function bbstyle(bbnumber, bbname) {
             butnumber = arraypop(bbcode) - 1;
             txtarea.value += bbtags[butnumber + 1];
             buttext = eval('document.post.addbbcode' + butnumber + '.value');
-            eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0,(buttext.length - 1)) + '"');
+            eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0, (buttext.length - 1)) + '"');
         }
         imageTag = false; // All tags are closed including image tags :D
         txtarea.focus();
         return;
     }
 
-    if ((clientVer >= 4) && is_ie && is_win)
-    {
+    if ((clientVer >= 4) && is_ie && is_win) {
         theSelection = document.selection.createRange().text; // Get text selection
         if (theSelection) {
             // Add tags around selection
-            document.selection.createRange().text = bbtags[bbnumber] + theSelection + bbtags[bbnumber+1];
+            document.selection.createRange().text = bbtags[bbnumber] + theSelection + bbtags[bbnumber + 1];
             txtarea.focus();
             theSelection = '';
             return;
         }
-    }
-    else if (txtarea.selectionEnd && (txtarea.selectionEnd - txtarea.selectionStart > 0))
-    {
-        mozWrap(txtarea, bbtags[bbnumber], bbtags[bbnumber+1]);
+    } else if (txtarea.selectionEnd && (txtarea.selectionEnd - txtarea.selectionStart > 0)) {
+        mozWrap(txtarea, bbtags[bbnumber], bbtags[bbnumber + 1]);
         return;
     }
 
     // Find last occurance of an open tag the same as the one just clicked
     for (i = 0; i < bbcode.length; i++) {
-        if (bbcode[i] == bbnumber+1) {
+        if (bbcode[i] == bbnumber + 1) {
             bblast = i;
             donotinsert = true;
         }
@@ -79,28 +75,27 @@ function bbstyle(bbnumber, bbname) {
 
     if (donotinsert) {		// Close all open tags up to the one just clicked & default button names
         while (bbcode[bblast]) {
-                butnumber = arraypop(bbcode) - 1;
-                txtarea.value += bbtags[butnumber + 1];
-                buttext = eval('document.post.addbbcode' + butnumber + '.value');
-                eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0,(buttext.length - 1)) + '"');
-                imageTag = false;
-            }
-            txtarea.focus();
-            return;
+            butnumber = arraypop(bbcode) - 1;
+            txtarea.value += bbtags[butnumber + 1];
+            buttext = eval('document.post.addbbcode' + butnumber + '.value');
+            eval('document.post.addbbcode' + butnumber + '.value ="' + buttext.substr(0, (buttext.length - 1)) + '"');
+            imageTag = false;
+        }
+        txtarea.focus();
+        return;
     } else { // Open tags
-
         if (imageTag && (bbnumber != 14)) {		// Close image tag before adding another
             txtarea.value += bbtags[15];
             lastValue = arraypop(bbcode) - 1;	// Remove the close image tag from the list
-            document.post.addbbcode14.value = "Img";	// Return button back to normal state
+            document.post.addbbcode14.value = 'Img';	// Return button back to normal state
             imageTag = false;
         }
 
         // Open tag
         txtarea.value += bbtags[bbnumber];
         if ((bbnumber == 14) && (imageTag == false)) imageTag = 1; // Check to stop additional tags after an unclosed image tag
-        arraypush(bbcode,bbnumber+1);
-        eval('document.post.addbbcode'+bbnumber+'.value += "*"');
+        arraypush(bbcode, bbnumber + 1);
+        eval('document.post.addbbcode' + bbnumber + '.value += "*"');
         txtarea.focus();
         return;
     }
@@ -108,67 +103,61 @@ function bbstyle(bbnumber, bbname) {
 }
 
 // From http://www.massless.org/mozedit/
-function mozWrap(txtarea, open, close)
-{
+function mozWrap (txtarea, open, close) {
     var selLength = txtarea.textLength;
     var selStart = txtarea.selectionStart;
     var selEnd = txtarea.selectionEnd;
-    if (selEnd == 1 || selEnd == 2)
-        selEnd = selLength;
+    if (selEnd == 1 || selEnd == 2) { selEnd = selLength; }
 
-    var s1 = (txtarea.value).substring(0,selStart);
+    var s1 = (txtarea.value).substring(0, selStart);
     var s2 = (txtarea.value).substring(selStart, selEnd)
     var s3 = (txtarea.value).substring(selEnd, selLength);
     txtarea.value = s1 + open + s2 + close + s3;
-    return;
 }
 
 // Insert at Claret position. Code from
 // http://www.faqts.com/knowledge_base/view.phtml/aid/1052/fid/130
-function storeCaret(textEl) {
+function storeCaret (textEl) {
     if (textEl.createTextRange) textEl.caretPos = document.selection.createRange().duplicate();
 }
 
-//This function is used for the 'on the fly' previews of interviews and reviews
-function previewText(text)
-{
-    text = text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+// This function is used for the 'on the fly' previews of interviews and reviews
+function previewText (text) {
+    text = text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
     text = text.replace(/\n\r?/g, '<br />');
-    text = text.replaceAll("[b]", "<b>");
-    text = text.replaceAll("[/b]", "</b>");
-    text = text.replaceAll("[u]", "<u>");
-    text = text.replaceAll("[/u]", "</u>");
-    text = text.replaceAll("[i]", "<i>");
-    text = text.replaceAll("[/i]", "</i>");
-    text = text.replaceAll("[url=", "<a href=");
-    text = text.replaceAll("[/url]", "</a>");
-    text = text.replaceAll("[email=", "<a href=mailto:");
-    text = text.replaceAll("[/email]", "</a>"); 
-    for (i = 0; i < 30; i++) 
-    {   
-        var hotspotUrl = "[hotspotUrl=#";
+    text = text.replaceAll('[b]', '<b>');
+    text = text.replaceAll('[/b]', '</b>');
+    text = text.replaceAll('[u]', '<u>');
+    text = text.replaceAll('[/u]', '</u>');
+    text = text.replaceAll('[i]', '<i>');
+    text = text.replaceAll('[/i]', '</i>');
+    text = text.replaceAll('[url=', '<a href=');
+    text = text.replaceAll('[/url]', '</a>');
+    text = text.replaceAll('[email=', '<a href=mailto:');
+    text = text.replaceAll('[/email]', '</a>');
+    for (i = 0; i < 30; i++) {
+        var hotspotUrl = '[hotspotUrl=#';
         var hotspotUrl_output = hotspotUrl.concat(i);
-        var hotspotUrl_final = hotspotUrl_output.concat("]");
-        var nameUrl = "<a href=#";
+        var hotspotUrl_final = hotspotUrl_output.concat(']');
+        var nameUrl = '<a href=#';
         var nameUrl_output = nameUrl.concat(i);
-        var nameUrl_final = nameUrl_output.concat(" class=standard_tile_link_black>");
+        var nameUrl_final = nameUrl_output.concat(' class=standard_tile_link_black>');
         text = text.replaceAll(hotspotUrl_final, nameUrl_final);
-        var hotspot = "[hotspot=";
+        var hotspot = '[hotspot=';
         var hotspot_output = hotspot.concat(i);
-        var hotspot_final = hotspot_output.concat("]");
-        var name = "<a name=";
+        var hotspot_final = hotspot_output.concat(']');
+        var name = '<a name=';
         var name_output = name.concat(i);
-        var name_final = name_output.concat(">");
+        var name_final = name_output.concat('>');
         text = text.replaceAll(hotspot_final, name_final);
-    }  
-    text = text.replaceAll("[/hotspotUrl]", "</a>");  
-    text = text.replaceAll("[/hotspot]", "</a>");   
-    text = text.replaceAll("]", " class=standard_tile_link_black>"); 
-    return text;  
+    }
+    text = text.replaceAll('[/hotspotUrl]', '</a>');
+    text = text.replaceAll('[/hotspot]', '</a>');
+    text = text.replaceAll(']', ' class=standard_tile_link_black>');
+    return text;
 }
 
-String.prototype.replaceAll = function(str1, str2, ignore)
-{
-    return this.replace(new RegExp(str1.replace(/([\/\,\!\\\^\$\{\}\[\]\(\)\.\*\+\?\|\<\>\-\&])/g,"\\$&"),(ignore?"gi":"g")),(typeof(str2)=="string")?str2.replace(/\$/g,"$$$$"):str2);
+String.prototype.replaceAll = function (str1, str2, ignore) {
+    return this.replace(new RegExp(str1.replace(/([\/\,\!\\\^\$\{\}\[\]\(\)\.\*\+\?\|\<\>\-\&])/g, '\\$&'), (ignore ? 'gi' : 'g')), (typeof (str2) === 'string') ? str2.replace(/\$/g, '$$$$') : str2);
 }
 /* END all the code for the text functions - BBCODE */

--- a/Website/AtariLegend/themes/templates/1/includes/js/forms.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/forms.js
@@ -1,46 +1,45 @@
-function formhash(form, password) {
-   // Create a new element input, this will be our hashed password field. 
-    var p = document.createElement("input");
- 
-    // Add the new element to our form. 
+function formhash (form, password) {
+    // Create a new element input, this will be our hashed password field.
+    var p = document.createElement('input');
+
+    // Add the new element to our form.
     form.appendChild(p);
-    p.name = "p";
-    p.type = "hidden";
+    p.name = 'p';
+    p.type = 'hidden';
     p.value = hex_sha512(password.value);
- 
-   // Create a new element input, this will be our md5 hashed password field. 
-    var pmd5 = document.createElement("input");
- 
-    // Add the new md5 element to our form. 
+
+    // Create a new element input, this will be our md5 hashed password field.
+    var pmd5 = document.createElement('input');
+
+    // Add the new md5 element to our form.
     form.appendChild(pmd5);
-    pmd5.name = "pmd5";
-    pmd5.type = "hidden";
+    pmd5.name = 'pmd5';
+    pmd5.type = 'hidden';
     pmd5.value = md5(password.value);
 
-    // Make sure the plaintext password doesn't get sent. 
-    password.value = "";
+    // Make sure the plaintext password doesn't get sent.
+    password.value = '';
 }
- 
-function regformhash(form, uid, email, password, conf) {
-     // Check each field has a value
-    if (uid.value == ''         || 
-          email.value == ''     || 
-          password.value == ''  || 
+
+function regformhash (form, uid, email, password, conf) {
+    // Check each field has a value
+    if (uid.value == '' ||
+          email.value == '' ||
+          password.value == '' ||
           conf.value == '') {
- 
         alert('You must provide all the requested details. Please try again');
         return false;
     }
- 
+
     // Check the username
- 
-    re = /^\w+$/; 
-    if(!re.test(form.username.value)) { 
-        alert("Username must contain only letters, numbers and underscores. Please try again"); 
+
+    re = /^\w+$/;
+    if (!re.test(form.username.value)) {
+        alert('Username must contain only letters, numbers and underscores. Please try again');
         form.username.focus();
-        return false; 
+        return false;
     }
- 
+
     // Check that the password is sufficiently long (min 6 chars)
     // The check is duplicated below, but this is included to give more
     // specific guidance to the user
@@ -49,37 +48,37 @@ function regformhash(form, uid, email, password, conf) {
         form.password.focus();
         return false;
     }
- 
-    // At least one number, one lowercase and one uppercase letter 
-    // At least six characters 
- 
-    var re = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}/; 
+
+    // At least one number, one lowercase and one uppercase letter
+    // At least six characters
+
+    var re = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}/;
     if (!re.test(password.value)) {
         alert('Passwords must contain at least one number, one lowercase and one uppercase letter.  Please try again');
         return false;
     }
- 
+
     // Check password and confirmation are the same
     if (password.value != conf.value) {
         alert('Your password and confirmation do not match. Please try again');
         form.password.focus();
         return false;
     }
- 
-    // Create a new element input, this will be our hashed password field. 
-    var p = document.createElement("input");
- 
-    // Add the new element to our form. 
+
+    // Create a new element input, this will be our hashed password field.
+    var p = document.createElement('input');
+
+    // Add the new element to our form.
     form.appendChild(p);
-    p.name = "p";
-    p.type = "hidden";
+    p.name = 'p';
+    p.type = 'hidden';
     p.value = hex_sha512(password.value);
- 
-    // Make sure the plaintext password doesn't get sent. 
-    password.value = "";
-    conf.value = "";
- 
-    // Finally submit the form. 
+
+    // Make sure the plaintext password doesn't get sent.
+    password.value = '';
+    conf.value = '';
+
+    // Finally submit the form.
     form.submit();
     return true;
 }

--- a/Website/AtariLegend/themes/templates/1/includes/js/menus.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/menus.js
@@ -4,54 +4,52 @@
  *
  */
 
- //This handles the queues
-(function($) {
-
+// This handles the queues
+(function ($) {
     // jQuery on an empty object, we are going to use this as our Queue
     var ajaxQueue = $({});
 
-    $.ajaxQueue = function(ajaxOpts) {
+    $.ajaxQueue = function (ajaxOpts) {
         var jqXHR,
-        dfd = $.Deferred(),
-        promise = dfd.promise();
+            dfd = $.Deferred(),
+            promise = dfd.promise();
 
-         // run the actual query
-         function doRequest(next) {
-             jqXHR = $.ajax(ajaxOpts);
-             jqXHR.done(dfd.resolve)
-                 .fail(dfd.reject)
-                 .then(next, next);
-         }
+        // run the actual query
+        function doRequest (next) {
+            jqXHR = $.ajax(ajaxOpts);
+            jqXHR.done(dfd.resolve)
+                .fail(dfd.reject)
+                .then(next, next);
+        }
 
-         // queue our ajax request
-         ajaxQueue.queue(doRequest);
+        // queue our ajax request
+        ajaxQueue.queue(doRequest);
 
-         // add the abort method
-         promise.abort = function(statusText) {
+        // add the abort method
+        promise.abort = function (statusText) {
+            // proxy abort to the jqXHR if it is active
+            if (jqXHR) {
+                return jqXHR.abort(statusText);
+            }
 
-             // proxy abort to the jqXHR if it is active
-             if (jqXHR) {
-                 return jqXHR.abort(statusText);
-             }
+            // if there wasn't already a jqXHR we need to remove from queue
+            var queue = ajaxQueue.queue(),
+                index = $.inArray(doRequest, queue);
 
-             // if there wasn't already a jqXHR we need to remove from queue
-             var queue = ajaxQueue.queue(),
-                 index = $.inArray(doRequest, queue);
+            if (index > -1) {
+                queue.splice(index, 1);
+            }
 
-             if (index > -1) {
-                 queue.splice(index, 1);
-             }
+            // and then reject the deferred
+            dfd.rejectWith(ajaxOpts.context || ajaxOpts, [promise, statusText, '']);
+            return promise;
+        };
 
-             // and then reject the deferred
-             dfd.rejectWith(ajaxOpts.context || ajaxOpts, [promise, statusText, ""]);
-             return promise;
-         };
+        return promise;
+    };
+})(jQuery);
 
-         return promise;
-     };
- })(jQuery);
-
-function OSDMessageDisplay(message) {
+function OSDMessageDisplay (message) {
     $.notify_osd.create({
         'text': message, // notification message
         'icon': '../../../themes/styles/1/images/osd_icons/star.png', // icon path, 48x48
@@ -61,660 +59,628 @@ function OSDMessageDisplay(message) {
     });
 }
 
-function editDisk(str) {
-    var disk_edit_ajax = "diskedit_ajax_".concat(str);
+function editDisk (str) {
+    var disk_edit_ajax = 'diskedit_ajax_'.concat(str);
     $.ajax({
         // The URL for the request
-        url: "ajax_menus_detail.php",
-        data: "action=edit_disk_box&menu_disk_id=" + str,
-        type: "GET",
-        dataType: "html",
+        url: 'ajax_menus_detail.php',
+        data: 'action=edit_disk_box&menu_disk_id=' + str,
+        type: 'GET',
+        dataType: 'html',
         // Code to run if the request succeeds;
         success: function (html) {
-            $("#" + disk_edit_ajax).html(html);
+            $('#' + disk_edit_ajax).html(html);
         }
     });
 }
 
-function CloseeditDisk(str) {
-    var disk_edit_ajax = "diskedit_ajax_".concat(str);
+function CloseeditDisk (str) {
+    var disk_edit_ajax = 'diskedit_ajax_'.concat(str);
     $.ajax({
         // The URL for the request
-        url: "ajax_menus_detail.php",
-        data: "action=close_edit_disk_box&menu_disk_id=" + str,
-        type: "GET",
-        dataType: "html",
+        url: 'ajax_menus_detail.php',
+        data: 'action=close_edit_disk_box&menu_disk_id=' + str,
+        type: 'GET',
+        dataType: 'html',
         // Code to run if the request succeeds;
         success: function (html) {
-            $("#" + disk_edit_ajax).html(html);
+            $('#' + disk_edit_ajax).html(html);
         }
     });
 }
 
-function popAddGames(str) {
-    if (str === "") {
-        $("#JSMenuDetailExpandGames").html("");
-        return;
+function popAddGames (str) {
+    if (str === '') {
+        $('#JSMenuDetailExpandGames').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_addgames_menus.php",
-            data: "action=game_browse&list=full&query=num&menu_disk_id=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_addgames_menus.php',
+            data: 'action=game_browse&list=full&query=num&menu_disk_id=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
             success: function (html) {
-                $("#JSMenuDetailExpandGames").html(html);
-                $("#gameto_menu_link").html("<a onclick=\"closeAddGames(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add Game/Tool/Demo to menu</a>");
+                $('#JSMenuDetailExpandGames').html(html);
+                $('#gameto_menu_link').html('<a onclick="closeAddGames(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add Game/Tool/Demo to menu</a>');
                 GameSearchListen();
             }
         });
     }
-} 
-
-function closeAddGames(str) {
-    $("#JSMenuDetailExpandGames").html("");
-    $("#gameto_menu_link").html("<a onclick=\"popAddGames(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add Game/Tool/Demo to menu</a>");
-    return;
 }
 
-function SearchingGame(GameSearchAction) {
-    if (GameSearchAction === "game_browse") {
-        var form_values = $("#game_search_menu").serialize() + "&action=game_browse&list=inner&query=" + $(".JSGameBrowse").val();
+function closeAddGames (str) {
+    $('#JSMenuDetailExpandGames').html('');
+    $('#gameto_menu_link').html('<a onclick="popAddGames(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add Game/Tool/Demo to menu</a>');
+}
+
+function SearchingGame (GameSearchAction) {
+    if (GameSearchAction === 'game_browse') {
+        var form_values = $('#game_search_menu').serialize() + '&action=game_browse&list=inner&query=' + $('.JSGameBrowse').val();
     } else {
-        if (GameSearchAction === "game_search") {
-            var form_values = $("#game_search_menu").serialize() + "&action=game_search&list=inner&query=" + $(".JSGameSearch").val();
+        if (GameSearchAction === 'game_search') {
+            var form_values = $('#game_search_menu').serialize() + '&action=game_search&list=inner&query=' + $('.JSGameSearch').val();
         }
     }
     $.ajaxQueue({
         // The URL for the request
-        url: "ajax_addgames_menus.php",
+        url: 'ajax_addgames_menus.php',
         data: form_values,
-        type: "GET",
-        dataType: "html",
+        type: 'GET',
+        dataType: 'html',
         // Code to run if the request succeeds;
         success: function (html) {
-            $("#game_list").html(html);
+            $('#game_list').html(html);
         }
     });
 }
 
-function GameSearchListen() {
-    $(".JSGameBrowse").change(function () {
-        SearchingGame("game_browse");
+function GameSearchListen () {
+    $('.JSGameBrowse').change(function () {
+        SearchingGame('game_browse');
     });
 
-    $(".JSGameSearch").keyup(function () {
+    $('.JSGameSearch').keyup(function () {
         var value = $(this).val();
         if (value.length >= 3) {
-            SearchingGame("game_search");
+            SearchingGame('game_search');
         }
     });
 }
 
-function SearchingDoc(DocSearchAction) {
-    if (DocSearchAction === "doc_browse") {
-        var form_values = $("#doc_search_menu").serialize() + "&action=game_browse&list=inner&query=" + $(".JSDocBrowse").val();
+function SearchingDoc (DocSearchAction) {
+    if (DocSearchAction === 'doc_browse') {
+        var form_values = $('#doc_search_menu').serialize() + '&action=game_browse&list=inner&query=' + $('.JSDocBrowse').val();
     } else {
-        if (DocSearchAction === "doc_search") {
-            var form_values = $("#doc_search_menu").serialize() + "&action=game_search&list=inner&query=" + $(".JSDocSearch").val();
+        if (DocSearchAction === 'doc_search') {
+            var form_values = $('#doc_search_menu').serialize() + '&action=game_search&list=inner&query=' + $('.JSDocSearch').val();
         }
     }
     $.ajaxQueue({
         // The URL for the request
-        url: "ajax_adddocs_menus.php",
+        url: 'ajax_adddocs_menus.php',
         data: form_values,
-        type: "GET",
-        dataType: "html",
+        type: 'GET',
+        dataType: 'html',
         // Code to run if the request succeeds;
         success: function (html) {
-            $("#doc_list").html(html);
+            $('#doc_list').html(html);
         }
     });
 }
 
-function DocSearchListen() {
-    $(".JSDocBrowse").change(function () {
-        SearchingDoc("doc_browse");
+function DocSearchListen () {
+    $('.JSDocBrowse').change(function () {
+        SearchingDoc('doc_browse');
     });
 
-    $(".JSDocSearch").keyup(function () {
+    $('.JSDocSearch').keyup(function () {
         var value = $(this).val();
         if (value.length >= 3) {
-            SearchingDoc("doc_search");
+            SearchingDoc('doc_search');
         }
     });
 }
 
-
-function addGametoMenu(software_id, menu_disk_id, software_type) {
-    if (software_id === "") {
-        $("#JSMenuSoftwareList").html("");
-        return;
+function addGametoMenu (software_id, menu_disk_id, software_type) {
+    if (software_id === '') {
+        $('#JSMenuSoftwareList').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=add_title_to_menu&software_id=" + software_id + "&menu_disk_id=" + menu_disk_id + "&software_type=" + software_type,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=add_title_to_menu&software_id=' + software_id + '&menu_disk_id=' + menu_disk_id + '&software_type=' + software_type,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#JSMenuSoftwareList").html(ReturnHtml[0]);
+                $('#JSMenuSoftwareList').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
             }
         });
     }
 }
 
-function addNewdisk(str) {
-    if (str === "") {
-        $("#new_disk").html("");
-        return;
+function addNewdisk (str) {
+    if (str === '') {
+        $('#new_disk').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_menus.php",
-            data: "action=add_new_disk_box&menu_sets_id=" + str,
-            type: "POST",
-            dataType: "html",
+            url: 'ajax_menus.php',
+            data: 'action=add_new_disk_box&menu_sets_id=' + str,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#new_disk").html(html);
-                $("#close_new_disk").html("<a onclick=\"CloseaddNewdisk(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add New Disk</a>");
+            success: function (html) {
+                $('#new_disk').html(html);
+                $('#close_new_disk').html('<a onclick="CloseaddNewdisk(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add New Disk</a>');
             }
         });
     }
 }
 
-function CloseaddNewdisk(str) {
-    $("#new_disk").html("");
-    $("#close_new_disk").html("<a onclick=\"addNewdisk(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add New Disk</a>");
-    return;
+function CloseaddNewdisk (str) {
+    $('#new_disk').html('');
+    $('#close_new_disk').html('<a onclick="addNewdisk(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add New Disk</a>');
 }
 
-function myFunction() {
+function myFunction () {
     $but = $('#file_upload_game_file');
-    $("input:file[id=file_upload]").change(function() {
+    $('input:file[id=file_upload]').change(function () {
         document.getElementById('file_upload_game_screenshots').value = 'file(s) selected';
     });
-    $("input:file[id=file_upload2]").change(function() {
+    $('input:file[id=file_upload2]').change(function () {
         document.getElementById('file_upload_game_file').value = $(this).val();
     });
 }
 
-function browseCrew(str) {
-    if (str === "") {
-        $("#option_crew").html("");
-        return;
+function browseCrew (str) {
+    if (str === '') {
+        $('#option_crew').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_menus.php",
-            data: "action=crew_browse&query=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_menus.php',
+            data: 'action=crew_browse&query=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#option_crew").html(html);
+            success: function (html) {
+                $('#option_crew').html(html);
             }
         });
     }
 }
 
-function browseIndividual(str) {
-    if (str === "") {
-        $("#option_ind").html("");
-        return;
+function browseIndividual (str) {
+    if (str === '') {
+        $('#option_ind').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_menus.php",
-            data: "action=ind_browse&query=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_menus.php',
+            data: 'action=ind_browse&query=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#option_ind").html(html);
+            success: function (html) {
+                $('#option_ind').html(html);
             }
         });
     }
 }
 
-function browseInd(str) {
-    if (str === "") {
-        $("#ind_member").html("");
-        return;
+function browseInd (str) {
+    if (str === '') {
+        $('#ind_member').html('');
     } else {
         $.ajaxQueue({
             // The URL for the request
-            url: "ajax_menus_detail.php",
-            data: "action=ind_gen_browse&query=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_menus_detail.php',
+            data: 'action=ind_gen_browse&query=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#ind_member").html(html);
+            success: function (html) {
+                $('#ind_member').html(html);
             }
         });
     }
 }
 
-function searchInd(str) {
-    if (str === "") {
-        $("#ind_member").html("");
+function searchInd (str) {
+    if (str === '') {
+        $('#ind_member').html('');
     } else {
         $.ajaxQueue({
             // The URL for the request
-            url: "ajax_menus_detail.php",
-            data: "action=ind_gen_search&query=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_menus_detail.php',
+            data: 'action=ind_gen_search&query=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#ind_member").html(html);
+            success: function (html) {
+                $('#ind_member').html(html);
             }
         });
     }
 }
 
-function popAddIntroCred(str) {
-    if (str === "") {
-        $("#menu_detail_expand").html("");
-        return;
+function popAddIntroCred (str) {
+    if (str === '') {
+        $('#menu_detail_expand').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_menus_detail.php",
-            data: "action=add_intro_credit&query=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_menus_detail.php',
+            data: 'action=add_intro_credit&query=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#menu_detail_expand").html(html);
-                $("#intro_credit_link").html("<a onclick=\"closeAddIntroCred(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add intro credits</a>");
+            success: function (html) {
+                $('#menu_detail_expand').html(html);
+                $('#intro_credit_link').html('<a onclick="closeAddIntroCred(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add intro credits</a>');
             }
         });
     }
 }
 
-function closeAddIntroCred(str) {
-    $("#menu_detail_expand").html("");
-    $("#intro_credit_link").html("<a onclick=\"popAddIntroCred(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add intro credits</a>");
-    return;
+function closeAddIntroCred (str) {
+    $('#menu_detail_expand').html('');
+    $('#intro_credit_link').html('<a onclick="popAddIntroCred(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add intro credits</a>');
 }
 
-function popAddAuthorMenutitle(menu_disk_title_id, game_id, game_name) {
-    if (menu_disk_title_id === "") {
-        $("#menu_detail_expand_author_title").html("");
-        return;
+function popAddAuthorMenutitle (menu_disk_title_id, game_id, game_name) {
+    if (menu_disk_title_id === '') {
+        $('#menu_detail_expand_author_title').html('');
     } else {
         $.ajaxQueue({
             // The URL for the request
-            url: "ajax_add_author_menutitle.php",
-            data: "menu_disk_title_id=" + menu_disk_title_id + "&game_name=" + game_name + "&game_id=" + game_id,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_add_author_menutitle.php',
+            data: 'menu_disk_title_id=' + menu_disk_title_id + '&game_name=' + game_name + '&game_id=' + game_id,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#menu_detail_expand_author_title").html(html);
-                $("#author_to_menu_title" + game_id).html("<a onclick=\"closeAddAuthor(" + menu_disk_title_id + "," + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + "</a>");
+            success: function (html) {
+                $('#menu_detail_expand_author_title').html(html);
+                $('#author_to_menu_title' + game_id).html('<a onclick="closeAddAuthor(' + menu_disk_title_id + ',' + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + '</a>');
             }
         });
     }
 }
 
-function closeAddAuthor(menu_disk_title_id, game_id, game_name) {
-    $("#menu_detail_expand_author_title").html("");
-    $("#author_to_menu_title" + game_id).html("<a onclick=\"popAddAuthorMenutitle(" + menu_disk_title_id + "," + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + "</a>");
-    return;
+function closeAddAuthor (menu_disk_title_id, game_id, game_name) {
+    $('#menu_detail_expand_author_title').html('');
+    $('#author_to_menu_title' + game_id).html('<a onclick="popAddAuthorMenutitle(' + menu_disk_title_id + ',' + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + '</a>');
 }
 
-function popAddAuthorMenutitleDoc(menu_disk_title_id, game_id, game_name) {
-    if (menu_disk_title_id === "") {
-        $("#menu_detail_expand_author_title_doc").html("");
-        return;
+function popAddAuthorMenutitleDoc (menu_disk_title_id, game_id, game_name) {
+    if (menu_disk_title_id === '') {
+        $('#menu_detail_expand_author_title_doc').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_add_author_menutitle.php",
-            data: "menu_disk_title_id=" + menu_disk_title_id + "&game_name=" + game_name + "&game_id=" + game_id,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_add_author_menutitle.php',
+            data: 'menu_disk_title_id=' + menu_disk_title_id + '&game_name=' + game_name + '&game_id=' + game_id,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#menu_detail_expand_author_title_doc").html(html);
-                $("#author_to_menu_title_doc" + game_id).html("<a onclick=\"closeAddAuthorDoc(" + menu_disk_title_id + "," + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + "</a>");
+            success: function (html) {
+                $('#menu_detail_expand_author_title_doc').html(html);
+                $('#author_to_menu_title_doc' + game_id).html('<a onclick="closeAddAuthorDoc(' + menu_disk_title_id + ',' + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + '</a>');
             }
         });
     }
 }
 
-function closeAddAuthorDoc(menu_disk_title_id, game_id, game_name) {
-    $("#menu_detail_expand_author_title_doc").html("");
-    $("#author_to_menu_title_doc" + game_id).html("<a onclick=\"popAddAuthorMenutitleDoc(" + menu_disk_title_id + "," + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + "</a>");
-    return;
+function closeAddAuthorDoc (menu_disk_title_id, game_id, game_name) {
+    $('#menu_detail_expand_author_title_doc').html('');
+    $('#author_to_menu_title_doc' + game_id).html('<a onclick="popAddAuthorMenutitleDoc(' + menu_disk_title_id + ',' + game_id + ",'" + game_name + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">" + game_name + '</a>');
 }
 
-function popAddDocs(str) {
-    if (str === "") {
-        $("#menu_detail_expand_docs").html("");
-        return;
+function popAddDocs (str) {
+    if (str === '') {
+        $('#menu_detail_expand_docs').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_adddocs_menus.php",
-            data: "action=game_browse&list=full&query=num&menu_disk_id=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_adddocs_menus.php',
+            data: 'action=game_browse&list=full&query=num&menu_disk_id=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#menu_detail_expand_docs").html(html);
-                $("#docto_menu_link").html("<a onclick=\"closeAddDocs(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add Doc to menu</a>");
+            success: function (html) {
+                $('#menu_detail_expand_docs').html(html);
+                $('#docto_menu_link').html('<a onclick="closeAddDocs(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add Doc to menu</a>');
                 DocSearchListen();
             }
         });
     }
 }
 
-function closeAddDocs(str) {
-    $("#menu_detail_expand_docs").html("");
-    $("#docto_menu_link").html("<a onclick=\"popAddDocs(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add Doc to menu</a>");
-    return;
+function closeAddDocs (str) {
+    $('#menu_detail_expand_docs').html('');
+    $('#docto_menu_link').html('<a onclick="popAddDocs(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add Doc to menu</a>');
 }
 
-function popAddScreenshots(str) {
-    if (str === "") {
-        $("#JSMenuDetailExpandScreenshots").html("");
-        return;
+function popAddScreenshots (str) {
+    if (str === '') {
+        $('#JSMenuDetailExpandScreenshots').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_addscreenshots_menus.php",
-            data: "menu_disk_id=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_addscreenshots_menus.php',
+            data: 'menu_disk_id=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#JSMenuDetailExpandScreenshots").html(html);
-                $("#screenshot_link").html("<a onclick=\"closeAddScreenshots(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add Screenshots to menu</a>");
+            success: function (html) {
+                $('#JSMenuDetailExpandScreenshots').html(html);
+                $('#screenshot_link').html('<a onclick="closeAddScreenshots(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add Screenshots to menu</a>');
             }
         });
     }
 }
 
-function closeAddScreenshots(str) {
-    $("#JSMenuDetailExpandScreenshots").html("");
-    $("#screenshot_link").html("<a onclick=\"popAddScreenshots(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add Screenshots to menu</a>");
-    return;
+function closeAddScreenshots (str) {
+    $('#JSMenuDetailExpandScreenshots').html('');
+    $('#screenshot_link').html('<a onclick="popAddScreenshots(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add Screenshots to menu</a>');
 }
 
-function popAddFile(str) {
-    if (str === "") {
-        $("#JSMenuDetailExpandFile").html("");
-        return;
+function popAddFile (str) {
+    if (str === '') {
+        $('#JSMenuDetailExpandFile').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_addfile_menus.php",
-            data: "menu_disk_id=" + str,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_addfile_menus.php',
+            data: 'menu_disk_id=' + str,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#JSMenuDetailExpandFile").html(html);
-                $("#file_link").html("<a onclick=\"closeAddFile(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add File to menu</a>");
+            success: function (html) {
+                $('#JSMenuDetailExpandFile').html(html);
+                $('#file_link').html('<a onclick="closeAddFile(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add File to menu</a>');
             }
         });
     }
 }
 
-function closeAddFile(str) {
-    $("#JSMenuDetailExpandFile").html("");
-    $("#file_link").html("<a onclick=\"popAddFile(" + str + ")\" style=\"cursor: pointer;\" class=\"MAINNAV\">Add File to menu</a>");
-    return;
+function closeAddFile (str) {
+    $('#JSMenuDetailExpandFile').html('');
+    $('#file_link').html('<a onclick="popAddFile(' + str + ')" style="cursor: pointer;" class="MAINNAV">Add File to menu</a>');
 }
 
-function addslashes(str) {
+function addslashes (str) {
     return (str + '').replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0');
 }
 
-function popAddSet(str, menu_disk_id, title_name) {
-    if (str === "") {
-        $("#JSMenuDetailExpandSet").html("");
-        return;
+function popAddSet (str, menu_disk_id, title_name) {
+    if (str === '') {
+        $('#JSMenuDetailExpandSet').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "ajax_addset_menus.php",
-            data: "menu_disk_title_id=" + str + "&menu_disk_id=" + menu_disk_id + "&title_name=" + title_name,
-            type: "GET",
-            dataType: "html",
+            url: 'ajax_addset_menus.php',
+            data: 'menu_disk_title_id=' + str + '&menu_disk_id=' + menu_disk_id + '&title_name=' + title_name,
+            type: 'GET',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
-                $("#JSMenuDetailExpandSet").html(html);
+            success: function (html) {
+                $('#JSMenuDetailExpandSet').html(html);
                 var title = addslashes(title_name);
-                $("#" + str).html("<a onclick=\"closeAddSet(" + str + "," + menu_disk_id + ",'" + title + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">Add</a>");
+                $('#' + str).html('<a onclick="closeAddSet(' + str + ',' + menu_disk_id + ",'" + title + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">Add</a>");
             }
         });
-        var elementExists = document.getElementById("set_chain_update");
-        if (typeof(elementExists) != 'undefined' && elementExists !== null) {
-            $("#set_chain_update").html("");
+        var elementExists = document.getElementById('set_chain_update');
+        if (typeof (elementExists) !== 'undefined' && elementExists !== null) {
+            $('#set_chain_update').html('');
         }
     }
 }
 
-function closeAddSet(str, menu_disk_id, title_name) {
+function closeAddSet (str, menu_disk_id, title_name) {
     var title = addslashes(title_name);
-    $("#JSMenuDetailExpandSet").html("");
-    $("#" + str).html("<a onclick=\"popAddSet(" + str + "," + menu_disk_id + ",'" + title + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">Add</a>");
-    return;
+    $('#JSMenuDetailExpandSet').html('');
+    $('#' + str).html('<a onclick="popAddSet(' + str + ',' + menu_disk_id + ",'" + title + "')\" style=\"cursor: pointer;\" class=\"standard_tile_link\">Add</a>");
 }
 
-function addAuthorstoMenutitle(menu_disk_title_id) {
-    if (menu_disk_title_id === "") {
-        $("#author_list").html("");
-        return;
+function addAuthorstoMenutitle (menu_disk_title_id) {
+    if (menu_disk_title_id === '') {
+        $('#author_list').html('');
     } else {
-        var form_values = $("#authors_form").serialize();
+        var form_values = $('#authors_form').serialize();
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
+            url: 'db_menu_disk.php',
             data: form_values,
-            type: "POST",
-            dataType: "html",
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#author_list").html(ReturnHtml[0]);
+                $('#author_list').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
             }
         });
     }
 }
 
-function addDoctoMenu(software_id, menu_disk_id, software_type) {
-    if (software_id === "") {
-        $("#menu_doc_list").html("");
-        return;
+function addDoctoMenu (software_id, menu_disk_id, software_type) {
+    if (software_id === '') {
+        $('#menu_doc_list').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=add_doc_to_menu&software_id=" + software_id + "&menu_disk_id=" + menu_disk_id + "&software_type=" + software_type,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=add_doc_to_menu&software_id=' + software_id + '&menu_disk_id=' + menu_disk_id + '&software_type=' + software_type,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#menu_doc_list").html(ReturnHtml[0]);
+                $('#menu_doc_list').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
             }
         });
     }
 }
 
-function addScreenshottoMenu(menu_disk_id) {
-    if (menu_disk_id === "") {
-        $("#JSMenuScreenshotList").html("");
-        return;
+function addScreenshottoMenu (menu_disk_id) {
+    if (menu_disk_id === '') {
+        $('#JSMenuScreenshotList').html('');
     } else {
         if (window.XMLHttpRequest) {
             // code for IE7+, Firefox, Chrome, Opera, Safari
             xmlhttp = new XMLHttpRequest();
         } else {
             // code for IE6, IE5
-            xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
+            xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
         }
-        xmlhttp.onreadystatechange = function() {
+        xmlhttp.onreadystatechange = function () {
             if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
-                data = xmlhttp.responseText.split("[BRK]");
-                document.getElementById("JSMenuScreenshotList").innerHTML = data[0];
+                data = xmlhttp.responseText.split('[BRK]');
+                document.getElementById('JSMenuScreenshotList').innerHTML = data[0];
                 OSDMessageDisplay(data[1]);
-                document.getElementById("screenshot_add_to_menu").reset();
+                document.getElementById('screenshot_add_to_menu').reset();
             }
         }
-        var formData = new FormData(document.getElementById("screenshot_add_to_menu"));
-        xmlhttp.open("POST", "../menus/db_menu_disk.php", true);
+        var formData = new FormData(document.getElementById('screenshot_add_to_menu'));
+        xmlhttp.open('POST', '../menus/db_menu_disk.php', true);
         xmlhttp.send(formData);
     }
 }
 
-function addFiletoMenu(menu_disk_id) {
-    if (menu_disk_id === "") {
-        $("#JSMenuFileList").html("");
-        return;
+function addFiletoMenu (menu_disk_id) {
+    if (menu_disk_id === '') {
+        $('#JSMenuFileList').html('');
     } else {
         if (window.XMLHttpRequest) {
             // code for IE7+, Firefox, Chrome, Opera, Safari
             xmlhttp = new XMLHttpRequest();
         } else {
             // code for IE6, IE5
-            xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
+            xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
         }
-        xmlhttp.onreadystatechange = function() {
+        xmlhttp.onreadystatechange = function () {
             if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
-                data = xmlhttp.responseText.split("[BRK]");
-                document.getElementById("JSMenuFileList").innerHTML = data[0];
+                data = xmlhttp.responseText.split('[BRK]');
+                document.getElementById('JSMenuFileList').innerHTML = data[0];
                 OSDMessageDisplay(data[1]);
-                document.getElementById("File_add_to_menu").reset();
+                document.getElementById('File_add_to_menu').reset();
             }
         }
-        var formData = new FormData(document.getElementById("file_add_to_menu"));
-        xmlhttp.open("POST", "../menus/db_menu_disk.php", true);
+        var formData = new FormData(document.getElementById('file_add_to_menu'));
+        xmlhttp.open('POST', '../menus/db_menu_disk.php', true);
         xmlhttp.send(formData);
     }
 }
 
-function LinkChain(menu_disk_title_id, menu_disk_id) {
-    if (menu_disk_title_id === "") {
-        $("#JSMenuSoftwareList").html("");
-        return;
+function LinkChain (menu_disk_title_id, menu_disk_id) {
+    if (menu_disk_title_id === '') {
+        $('#JSMenuSoftwareList').html('');
     } else {
-        var form_values = $("#link_game_to_set").serialize();
+        var form_values = $('#link_game_to_set').serialize();
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
+            url: 'db_menu_disk.php',
             data: form_values,
-            type: "POST",
-            dataType: "html",
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#JSMenuSoftwareList").html(ReturnHtml[0]);
+                $('#JSMenuSoftwareList').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
-                $("#JSMenuDetailExpandSet").html("");
+                $('#JSMenuDetailExpandSet').html('');
             }
         });
     }
 }
 
-function DeleteChain(menu_disk_title_id, menu_disk_id, title_name) {
-    if (menu_disk_title_id === "") {
-        $("#JSMenuSoftwareList").html("");
-        return;
+function DeleteChain (menu_disk_title_id, menu_disk_id, title_name) {
+    if (menu_disk_title_id === '') {
+        $('#JSMenuSoftwareList').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=delete_game_from_set&menu_disk_title_id=" + menu_disk_title_id + "&menu_disk_id=" + menu_disk_id + "&title_name=" + title_name,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=delete_game_from_set&menu_disk_title_id=' + menu_disk_title_id + '&menu_disk_id=' + menu_disk_id + '&title_name=' + title_name,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#JSMenuSoftwareList").html(ReturnHtml[0]);
+                $('#JSMenuSoftwareList').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
-                $("#JSMenuDetailExpandSet").html("");
+                $('#JSMenuDetailExpandSet').html('');
             }
         });
     }
 }
 
-function CreateChain(str, menu_disk_id) {
-    if (str === "") {
-        $("#JSMenuSoftwareList").html("");
-        return;
+function CreateChain (str, menu_disk_id) {
+    if (str === '') {
+        $('#JSMenuSoftwareList').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=add_set_to_menu&menu_disk_title_id=" + str + "&menu_disk_id=" + menu_disk_id,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=add_set_to_menu&menu_disk_title_id=' + str + '&menu_disk_id=' + menu_disk_id,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#JSMenuSoftwareList").html(ReturnHtml[0]);
+                $('#JSMenuSoftwareList').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
-                $("#JSMenuDetailExpandSet").html("");
+                $('#JSMenuDetailExpandSet').html('');
             }
         });
     }
 }
 
-function addCreditstoMenu(menu_disk_id) {
-    if (menu_disk_id === "") {
-        $("#menu_credit_list").html("");
-        return;
+function addCreditstoMenu (menu_disk_id) {
+    if (menu_disk_id === '') {
+        $('#menu_credit_list').html('');
     } else {
-        var ind_id = document.getElementById("menu_credits_form").elements.namedItem("ind_id").value;
-        var author_type_id = document.getElementById("menu_credits_form").elements.namedItem("author_type_id").value;
+        var ind_id = document.getElementById('menu_credits_form').elements.namedItem('ind_id').value;
+        var author_type_id = document.getElementById('menu_credits_form').elements.namedItem('author_type_id').value;
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=add_intro_credits&author_type_id=" + author_type_id + "&menu_disk_id=" + menu_disk_id + "&ind_id=" + ind_id,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=add_intro_credits&author_type_id=' + author_type_id + '&menu_disk_id=' + menu_disk_id + '&ind_id=' + ind_id,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#menu_credit_list").html(ReturnHtml[0]);
+                $('#menu_credit_list').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
-                document.getElementById("menu_credit_list").reset();
+                document.getElementById('menu_credit_list').reset();
             }
         });
     }
 }
 
-function ChangeState(state_id, menu_disk_id) {
-    var str2 = "diskedit_ajax_";
+function ChangeState (state_id, menu_disk_id) {
+    var str2 = 'diskedit_ajax_';
     var disk_edit_ajax = str2.concat(menu_disk_id);
-    if (menu_disk_id === "") {
-        $("#" + disk_edit_ajax).html("");
-        return;
+    if (menu_disk_id === '') {
+        $('#' + disk_edit_ajax).html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=change_menu_disk_state&state_id=" + state_id + "&menu_disk_id=" + menu_disk_id,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=change_menu_disk_state&state_id=' + state_id + '&menu_disk_id=' + menu_disk_id,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#" + disk_edit_ajax).html(ReturnHtml[0]);
+                $('#' + disk_edit_ajax).html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
                 document.getElementById(disk_edit_ajax).reset();
             }
@@ -722,45 +688,43 @@ function ChangeState(state_id, menu_disk_id) {
     }
 }
 
-function ChangeDoctype(doc_type_id, doc_id, menu_disk_id) {
-    if (doc_type_id === "") {
-        $("#menu_doc_list").html("");
-        return;
+function ChangeDoctype (doc_type_id, doc_id, menu_disk_id) {
+    if (doc_type_id === '') {
+        $('#menu_doc_list').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=change_doctype&doc_type_id=" + doc_type_id + "&doc_id=" + doc_id + "&menu_disk_id=" + menu_disk_id,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=change_doctype&doc_type_id=' + doc_type_id + '&doc_id=' + doc_id + '&menu_disk_id=' + menu_disk_id,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#menu_doc_list").html(ReturnHtml[0]);
+                $('#menu_doc_list').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
-                document.getElementById("menu_doc_list").reset();
+                document.getElementById('menu_doc_list').reset();
             }
         });
     }
 }
 
-function ChangeYear(year_id, menu_disk_id) {
-    var str2 = "diskedit_ajax_";
+function ChangeYear (year_id, menu_disk_id) {
+    var str2 = 'diskedit_ajax_';
     var disk_edit_ajax = str2.concat(menu_disk_id);
-    if (menu_disk_id === "") {
-        $("#" + disk_edit_ajax).html("");
-        return;
+    if (menu_disk_id === '') {
+        $('#' + disk_edit_ajax).html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=change_menu_disk_year&year_id=" + year_id + "&menu_disk_id=" + menu_disk_id,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=change_menu_disk_year&year_id=' + year_id + '&menu_disk_id=' + menu_disk_id,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#" + disk_edit_ajax).html(ReturnHtml[0]);
+                $('#' + disk_edit_ajax).html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
                 document.getElementById(disk_edit_ajax).reset();
             }
@@ -768,23 +732,22 @@ function ChangeYear(year_id, menu_disk_id) {
     }
 }
 
-function ChangeParent(parent_id, menu_disk_id) {
-    var str2 = "diskedit_ajax_";
+function ChangeParent (parent_id, menu_disk_id) {
+    var str2 = 'diskedit_ajax_';
     var disk_edit_ajax = str2.concat(menu_disk_id);
-    if (menu_disk_id === "") {
-        $("#disk_edit_ajax").html("");
-        return;
+    if (menu_disk_id === '') {
+        $('#disk_edit_ajax').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=change_menu_disk_parent&parent_id=" + parent_id + "&menu_disk_id=" + menu_disk_id,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=change_menu_disk_parent&parent_id=' + parent_id + '&menu_disk_id=' + menu_disk_id,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#" + disk_edit_ajax).html(ReturnHtml[0]);
+                $('#' + disk_edit_ajax).html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
                 document.getElementById(disk_edit_ajax).reset();
             }
@@ -792,340 +755,339 @@ function ChangeParent(parent_id, menu_disk_id) {
     }
 }
 // Are you sure question Delete
-function DeleteGamefromMenuButton(str, menu_disk_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete Title",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this title from the menu disk?"),
+function DeleteGamefromMenuButton (str, menu_disk_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete Title',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this title from the menu disk?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete title": function() {
-                $(this).dialog("close");
+            'Delete title': function () {
+                $(this).dialog('close');
                 DeleteGamefromMenu(str, menu_disk_id);
             },
-            Cancel: function() {
-                $(this).dialog("close");
-                $("#menu_disk_title_id" + str).prop("checked", false);
+            Cancel: function () {
+                $(this).dialog('close');
+                $('#menu_disk_title_id' + str).prop('checked', false);
             }
         }
     });
 }
 
-function DeleteGamefromMenu(menu_disk_title_id, menu_disk_id) {
-    if (menu_disk_title_id === "") {
-        $("#JSMenuSoftwareList").html("");
-        return;
+function DeleteGamefromMenu (menu_disk_title_id, menu_disk_id) {
+    if (menu_disk_title_id === '') {
+        $('#JSMenuSoftwareList').html('');
     } else {
         $.ajax({
             // The URL for the request
-            url: "db_menu_disk.php",
-            data: "action=delete_from_menu_disk&menu_disk_title_id=" + menu_disk_title_id + "&menu_disk_id=" + menu_disk_id,
-            type: "POST",
-            dataType: "html",
+            url: 'db_menu_disk.php',
+            data: 'action=delete_from_menu_disk&menu_disk_title_id=' + menu_disk_title_id + '&menu_disk_id=' + menu_disk_id,
+            type: 'POST',
+            dataType: 'html',
             // Code to run if the request succeeds;
-            success: function(html) {
+            success: function (html) {
                 var ReturnHtml = html.split('[BRK]');
-                $("#JSMenuSoftwareList").html(ReturnHtml[0]);
+                $('#JSMenuSoftwareList').html(ReturnHtml[0]);
                 OSDMessageDisplay(ReturnHtml[1]);
             }
         });
     }
 }
 
-function DeleteMenuDiskModal(menu_disk_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete Disk?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this menu disk?"),
+function DeleteMenuDiskModal (menu_disk_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete Disk?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this menu disk?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete disk": function() {
-                $(this).dialog("close");
+            'Delete disk': function () {
+                $(this).dialog('close');
                 DeleteMenuDisk(menu_disk_id);
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function DeleteMenuDisk(menu_disk_id) {
-    var str2 = "diskedit_ajax_";
+function DeleteMenuDisk (menu_disk_id) {
+    var str2 = 'diskedit_ajax_';
     var disk_edit_ajax = str2.concat(menu_disk_id);
     $.ajax({
         // The URL for the request
-        url: "db_menu_disk.php",
-        data: "action=delete_menu_disk&menu_disk_id=" + menu_disk_id,
-        type: "POST",
-        dataType: "html",
+        url: 'db_menu_disk.php',
+        data: 'action=delete_menu_disk&menu_disk_id=' + menu_disk_id,
+        type: 'POST',
+        dataType: 'html',
         // Code to run if the request succeeds;
-        success: function(html) {
-            if (html == "Menudisk completely removed") {
-                $("#" + disk_edit_ajax).html("");
+        success: function (html) {
+            if (html == 'Menudisk completely removed') {
+                $('#' + disk_edit_ajax).html('');
             }
             OSDMessageDisplay(html);
         }
     });
 }
 
-function DeleteMenuSetIndividualModal(ind_select,menu_sets_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete Individual?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this Individual from the Menu Set?"),
+function DeleteMenuSetIndividualModal (ind_select, menu_sets_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete Individual?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this Individual from the Menu Set?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete disk": function() {
-                $(this).dialog("close");
-                url = "db_menu_disk.php?menu_sets_id=" + menu_sets_id +"&ind_id=" + ind_select + "&action=delete_ind_from_menu_set";
+            'Delete disk': function () {
+                $(this).dialog('close');
+                url = 'db_menu_disk.php?menu_sets_id=' + menu_sets_id + '&ind_id=' + ind_select + '&action=delete_ind_from_menu_set';
                 location.href = url;
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function DeleteMenuSetCrewModal(crew_select,menu_sets_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete Crew?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this Crew from the Menu Set?"),
+function DeleteMenuSetCrewModal (crew_select, menu_sets_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete Crew?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this Crew from the Menu Set?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete disk": function() {
-                $(this).dialog("close");
-                url = "db_menu_disk.php?menu_sets_id=" + menu_sets_id + "&crew_id=" + crew_select + "&action=delete_crew_from_menu_set";
+            'Delete disk': function () {
+                $(this).dialog('close');
+                url = 'db_menu_disk.php?menu_sets_id=' + menu_sets_id + '&crew_id=' + crew_select + '&action=delete_crew_from_menu_set';
                 location.href = url;
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function MenuTypeDelete(menu_type_select,menu_sets_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete menu type?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this menu type from this menu set?"),
+function MenuTypeDelete (menu_type_select, menu_sets_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete menu type?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this menu type from this menu set?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete disk": function() {
-                $(this).dialog("close");
-                url = "db_menu_disk.php?menu_sets_id=" + menu_sets_id + "&menu_type_id=" + menu_type_select + "&action=delete_menu_type_from_menu_set";
+            'Delete disk': function () {
+                $(this).dialog('close');
+                url = 'db_menu_disk.php?menu_sets_id=' + menu_sets_id + '&menu_type_id=' + menu_type_select + '&action=delete_menu_type_from_menu_set';
                 location.href = url;
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function deleteScreenshotfromMenu(str, menu_disk_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete Screenshot?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this screenshot from this menu disk?"),
+function deleteScreenshotfromMenu (str, menu_disk_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete Screenshot?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this screenshot from this menu disk?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete": function() {
-                $(this).dialog("close");
+            'Delete': function () {
+                $(this).dialog('close');
                 $.ajax({
                     // The URL for the request
-                    url: "db_menu_disk.php",
-                    data: "action=delete_screen_from_menu_disk&screenshot_id=" + str + "&menu_disk_id=" + menu_disk_id,
-                    type: "POST",
-                    dataType: "html",
+                    url: 'db_menu_disk.php',
+                    data: 'action=delete_screen_from_menu_disk&screenshot_id=' + str + '&menu_disk_id=' + menu_disk_id,
+                    type: 'POST',
+                    dataType: 'html',
                     // Code to run if the request succeeds;
-                    success: function(html) {
+                    success: function (html) {
                         var ReturnHtml = html.split('[BRK]');
-                        $("#JSMenuScreenshotList").html(ReturnHtml[0]);
+                        $('#JSMenuScreenshotList').html(ReturnHtml[0]);
                         OSDMessageDisplay(ReturnHtml[1]);
                     }
                 });
             },
-            Cancel: function() {
-                $(this).dialog("close");
-                $("#JSMenuScreenshotList").html("");
+            Cancel: function () {
+                $(this).dialog('close');
+                $('#JSMenuScreenshotList').html('');
             }
         }
     });
 }
 
-function deleteDownload(str, menu_disk_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete download?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this download from this menu disk?"),
+function deleteDownload (str, menu_disk_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete download?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this download from this menu disk?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete": function() {
-                $(this).dialog("close");
+            'Delete': function () {
+                $(this).dialog('close');
                 $.ajax({
                     // The URL for the request
-                    url: "db_menu_disk.php",
-                    data: "action=delete_download_from_menu_disk&menu_disk_download_id=" + str + "&menu_disk_id=" + menu_disk_id,
-                    type: "POST",
-                    dataType: "html",
+                    url: 'db_menu_disk.php',
+                    data: 'action=delete_download_from_menu_disk&menu_disk_download_id=' + str + '&menu_disk_id=' + menu_disk_id,
+                    type: 'POST',
+                    dataType: 'html',
                     // Code to run if the request succeeds;
-                    success: function(html) {
+                    success: function (html) {
                         var ReturnHtml = html.split('[BRK]');
-                        $("#JSMenuFileList").html(ReturnHtml[0]);
+                        $('#JSMenuFileList').html(ReturnHtml[0]);
                         OSDMessageDisplay(ReturnHtml[1]);
                     }
                 });
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function deleteDocfromMenu(str, menu_disk_id) {
-    document.getElementById("menu_disk_title_id" + str).checked = false;
-    $("#JSGenericModal").dialog({
-        title: "Delete Doc title?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this doc title from this menu disk?"),
+function deleteDocfromMenu (str, menu_disk_id) {
+    document.getElementById('menu_disk_title_id' + str).checked = false;
+    $('#JSGenericModal').dialog({
+        title: 'Delete Doc title?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this doc title from this menu disk?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete": function() {
-                $(this).dialog("close");
+            'Delete': function () {
+                $(this).dialog('close');
                 $.ajax({
                     // The URL for the request
-                    url: "db_menu_disk.php",
-                    data: "action=delete_doc_from_menu_disk&menu_disk_title_id=" + str + "&menu_disk_id=" + menu_disk_id,
-                    type: "POST",
-                    dataType: "html",
+                    url: 'db_menu_disk.php',
+                    data: 'action=delete_doc_from_menu_disk&menu_disk_title_id=' + str + '&menu_disk_id=' + menu_disk_id,
+                    type: 'POST',
+                    dataType: 'html',
                     // Code to run if the request succeeds;
-                    success: function(html) {
+                    success: function (html) {
                         var ReturnHtml = html.split('[BRK]');
-                        $("#menu_doc_list").html(ReturnHtml[0]);
+                        $('#menu_doc_list').html(ReturnHtml[0]);
                         OSDMessageDisplay(ReturnHtml[1]);
                     }
                 });
             },
-            Cancel: function() {
-                $(this).dialog("close");
-                $("#menu_doc_list").html("");
+            Cancel: function () {
+                $(this).dialog('close');
+                $('#menu_doc_list').html('');
             }
         }
     });
 }
 
-function DeleteSet(str) {
-    $("#JSGenericModal").dialog({
-        title: "Delete menu set?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this set?"),
+function DeleteSet (str) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete menu set?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this set?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete disk": function() {
-                $(this).dialog("close");
-                url = "../menus/db_menu_disk.php?action=delete_set&menu_sets_id=" + str;
+            'Delete disk': function () {
+                $(this).dialog('close');
+                url = '../menus/db_menu_disk.php?action=delete_set&menu_sets_id=' + str;
                 location.href = url;
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function PublishSet(str, action) {
-    $("#JSGenericModal").dialog({
-        title: "Change Status?",
-        open: $("#JSGenericModalText").text("Are you sure you want to change status on this set?"),
+function PublishSet (str, action) {
+    $('#JSGenericModal').dialog({
+        title: 'Change Status?',
+        open: $('#JSGenericModalText').text('Are you sure you want to change status on this set?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Change": function() {
-                $(this).dialog("close");
-                url = "../menus/db_menu_disk.php?action=publish_set&online=" + action + "&menu_sets_id=" + str;
+            'Change': function () {
+                $(this).dialog('close');
+                url = '../menus/db_menu_disk.php?action=publish_set&online=' + action + '&menu_sets_id=' + str;
                 location.href = url;
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function DeleteCredits(menu_disk_credits_id, menu_disk_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete from credits?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this person from the credit list?"),
+function DeleteCredits (menu_disk_credits_id, menu_disk_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete from credits?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this person from the credit list?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete": function() {
-                $(this).dialog("close");
+            'Delete': function () {
+                $(this).dialog('close');
                 $.ajax({
                     // The URL for the request
-                    url: "db_menu_disk.php",
-                    data: "action=delete_menu_disk_credits&menu_disk_credits_id=" + menu_disk_credits_id + "&menu_disk_id=" + menu_disk_id,
-                    type: "POST",
-                    dataType: "html",
+                    url: 'db_menu_disk.php',
+                    data: 'action=delete_menu_disk_credits&menu_disk_credits_id=' + menu_disk_credits_id + '&menu_disk_id=' + menu_disk_id,
+                    type: 'POST',
+                    dataType: 'html',
                     // Code to run if the request succeeds;
-                    success: function(html) {
+                    success: function (html) {
                         var ReturnHtml = html.split('[BRK]');
-                        $("#menu_credit_list").html(ReturnHtml[0]);
+                        $('#menu_credit_list').html(ReturnHtml[0]);
                         OSDMessageDisplay(ReturnHtml[1]);
-                        document.getElementById("menu_credit_list").reset();
+                        document.getElementById('menu_credit_list').reset();
                     }
                 });
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });
 }
 
-function DeleteTitleCredits(menu_disk_title_id, ind_id, author_type_id) {
-    $("#JSGenericModal").dialog({
-        title: "Delete from credits?",
-        open: $("#JSGenericModalText").text("Are you sure you want to delete this person from the title credit list?"),
+function DeleteTitleCredits (menu_disk_title_id, ind_id, author_type_id) {
+    $('#JSGenericModal').dialog({
+        title: 'Delete from credits?',
+        open: $('#JSGenericModalText').text('Are you sure you want to delete this person from the title credit list?'),
         resizable: false,
         height: 200,
         modal: true,
         buttons: {
-            "Delete": function() {
-                $(this).dialog("close");
+            'Delete': function () {
+                $(this).dialog('close');
                 $.ajax({
                     // The URL for the request
-                    url: "db_menu_disk.php",
-                    data: "action=delete_menu_disk_title_credits&menu_disk_title_id=" + menu_disk_title_id + "&author_type_id=" + author_type_id + "+&ind_id=" + ind_id,
-                    type: "POST",
-                    dataType: "html",
+                    url: 'db_menu_disk.php',
+                    data: 'action=delete_menu_disk_title_credits&menu_disk_title_id=' + menu_disk_title_id + '&author_type_id=' + author_type_id + '+&ind_id=' + ind_id,
+                    type: 'POST',
+                    dataType: 'html',
                     // Code to run if the request succeeds;
-                    success: function(html) {
+                    success: function (html) {
                         var ReturnHtml = html.split('[BRK]');
-                        $("#author_list").html(ReturnHtml[0]);
+                        $('#author_list').html(ReturnHtml[0]);
                         OSDMessageDisplay(ReturnHtml[1]);
-                        document.getElementById("author_list").reset();
+                        document.getElementById('author_list').reset();
                     }
                 });
             },
-            Cancel: function() {
-                $(this).dialog("close");
+            Cancel: function () {
+                $(this).dialog('close');
             }
         }
     });

--- a/Website/AtariLegend/themes/templates/1/includes/js/responsive_layout.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/responsive_layout.js
@@ -1,78 +1,74 @@
-var ResponsiveLayout = function(table){
-	this.table = table; //hold Tabulator object
-	this.columns = [];
-	this.index = 0;
+var ResponsiveLayout = function (table) {
+    this.table = table; // hold Tabulator object
+    this.columns = [];
+    this.index = 0;
 };
 
-//generate resposivle columns list
-ResponsiveLayout.prototype.initialize = function(){
-	var columns=[];
+// generate resposivle columns list
+ResponsiveLayout.prototype.initialize = function () {
+    var columns = [];
 
-	//detemine level of responsivity for each column
-	this.table.columnManager.columnsByIndex.forEach(function(column){
-		var def = column.getDefinition();
+    // detemine level of responsivity for each column
+    this.table.columnManager.columnsByIndex.forEach(function (column) {
+        var def = column.getDefinition();
 
-		column.extensions.responsive = {order: typeof def.responsive === "undefined" ? 1 : def.responsive};
+        column.extensions.responsive = {order: typeof def.responsive === 'undefined' ? 1 : def.responsive};
 
-		if(column.extensions.responsive.order){
-			columns.push(column);
-		}
-	});
+        if (column.extensions.responsive.order) {
+            columns.push(column);
+        }
+    });
 
+    // sort list by responsivity
+    columns = columns.reverse();
+    columns = columns.sort(function (a, b) {
+        return b.extensions.responsive.order - a.extensions.responsive.order;
+    });
 
-	//sort list by responsivity
-	columns = columns.reverse();
-	columns = columns.sort(function(a, b){
-		return b.extensions.responsive.order - a.extensions.responsive.order;
-	});
-
-	this.columns = columns;
+    this.columns = columns;
 };
 
-ResponsiveLayout.prototype.update = function(){
-	var self = this,
-	working = true;
+ResponsiveLayout.prototype.update = function () {
+    var self = this,
+        working = true;
 
-	while(working){
+    while (working) {
+        let diff = self.table.columnManager.element.innerWidth() - self.table.columnManager.getWidth();
 
-		let diff = self.table.columnManager.element.innerWidth() -  self.table.columnManager.getWidth();
+        if (diff < 0) {
+            // table is too wide
+            let column = self.columns[self.index];
 
-		if(diff < 0){
-			//table is too wide
-			let column = self.columns[self.index];
+            if (column) {
+                column.hide();
+                self.index++;
+            } else {
+                working = false;
+            }
+        } else {
+            // table has spare space
+            let column = self.columns[self.index - 1];
 
-			if(column){
-				column.hide();
-				self.index ++;
-			}else{
-				working = false;
-			}
+            if (column) {
+                if (diff > 0) {
+                    if (diff >= column.getWidth()) {
+                        column.show();
+                        self.index--;
+                    } else {
+                        working = false;
+                    }
+                } else {
+                    working = false;
+                }
+            } else {
+                working = false;
+            }
+        }
 
-		}else{
-			//table has spare space
-			let column = self.columns[self.index -1];
-
-			if(column){
-				if(diff > 0){
-
-					if(diff >= column.getWidth()){
-						column.show();
-						self.index --;
-					}else{
-						working = false;
-					}
-				}else{
-					working = false;
-				}
-			}else{
-				working = false;
-			}
-		}
-
-		if(!self.table.rowManager.activeRowsCount){
-			self.table.rowManager.renderEmptyScroll();
-		}
-	}
+        if (!self.table.rowManager.activeRowsCount) {
+            self.table.rowManager.renderEmptyScroll();
+        }
+    }
 };
 
-Tabulator.registerExtension("responsiveLayout", ResponsiveLayout);
+Tabulator.registerExtension('responsiveLayout', ResponsiveLayout);

--- a/Website/AtariLegend/themes/templates/1/includes/js/ui.widgets.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/ui.widgets.js
@@ -1,24 +1,21 @@
-(function($) {
+(function ($) {
     /**
      * jQuery plugin to provide an alternative auto-completed input
      * field to an existing select dropdown */
     $.fn.altAutocomplete = function () {
         this.each(function () {
             // Get all attributes on our <select> tag
-            var selectElement = $(this);
-
-            var selectName = selectElement.attr('name'),
+            var selectElement = $(this),
+                selectName = selectElement.attr('name'),
                 // Currently selected label and value
-                selectedLabel = selectElement.find(':selected').text(), 
-                selectedValue = selectElement.find(':selected').val(),
+                selectedLabel = selectElement.find(':selected').text(),
                 // Various attribute we need to perform the auto-complete:
                 // - the Ajax endpoint
                 completeEndpoint = selectElement.data('alt-autocomplete-endpoint'),
                 // - Which element is used to toggle between select / input mode
-                toggleControl = selectElement.data('alt-autocomplete-toggle');
-
-            // Generate an ID for the auto-completed input based on the select name
-            var displaySelectId = selectName + '-autocomplete-display';
+                toggleControl = selectElement.data('alt-autocomplete-toggle'),
+                // Generate an ID for the auto-completed input based on the select name
+                displaySelectId = selectName + '-autocomplete-display';
 
             // Some select are initialized with '-'. We don't want to display
             // this in input mode, so clear it
@@ -27,21 +24,21 @@
             }
 
             // Setup the autocomplete input field
-            var autocompleteDisplayInput = $('<input type="text" class="ui-widget-inline standard_tile_input_small" id="'+displaySelectId+'" value="'+selectedLabel+'">');
+            var autocompleteDisplayInput = $('<input type="text" class="ui-widget-inline standard_tile_input_small" id="' + displaySelectId + '" value="' + selectedLabel + '">');
             autocompleteDisplayInput
                 .autocomplete({
                     source: completeEndpoint,
                     minLength: 2,
                     select: function (evt, ui) {
                         // Synchronize the <input> value with the <select> one
-                        
+
                         // When a selection is chosen, update the input
                         // with the label, and select the correct <option>
                         // within the <select>
                         $(this).val(ui.item.label);
                         selectElement.val(ui.item.value).trigger('change');
                         return false;
-                    },
+                    }
                 })
                 .insertAfter(selectElement);
 
@@ -51,7 +48,7 @@
                 // with label of the currently selected value
                 autocompleteDisplayInput.val($(this).find('option:selected').text());
             });
-    
+
             // Setup the toggle button
             $(toggleControl).click(function () {
                 // When the toggle is clicked, show/hide the
@@ -65,10 +62,9 @@
                 if (autocompleteDisplayInput.is(':visible')) {
                     $(this).attr('title', 'Click for dropdown mode');
                 } else {
-                    $(this).attr('title', 'Click for autocompleted input field mode');                    
+                    $(this).attr('title', 'Click for autocompleted input field mode');
                 }
             });
-
 
             // Everything is ready, now hide our <select> by default
             selectElement.toggleClass('ui-widget-hidden');

--- a/package.json
+++ b/package.json
@@ -2,25 +2,31 @@
   "name": "atarilegend",
   "version": "0.1.0",
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt-contrib-uglify": "~0.5.0",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-node": "^5.2.1",
+    "eslint-plugin-promise": "^3.6.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "grunt": "~1.0.1",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt-contrib-uglify": "~3.2.1",
     "grunt-contrib-watch": "^1.0.0",
+    "grunt-eslint": "^20.1.0",
     "grunt-phpcbf": "^0.1.1",
     "grunt-phpcs": "^0.4.0",
     "grunt-pleeease": "^1.4.0",
-    "grunt-sass": "^1.2.1",
+    "grunt-sass": "^2.0.0",
     "grunt-sass-lint": "^0.2.0",
     "grunt-scss-lint": "^0.5.0",
     "grunt-scss-stylize": "^0.6.0",
-    "grunt-stylefmt": "^2.0.0",
-    "grunt-stylelint": "^0.6.0"
+    "grunt-stylefmt": "^3.0.0",
+    "grunt-stylelint": "^0.9.0"
   },
   "description": "The Atarilegend project",
   "main": "Gruntfile.js",
   "dependencies": {
     "grunt-cli": "^1.2.0",
+    "npm-check-updates": "^2.13.0",
     "phplint": "^1.7.1"
   },
   "scripts": {


### PR DESCRIPTION
This configures Grunt to run ESLint to check for Javascript code issues,
both formatting and coding errors.

I had to upgrade Grunt to the latest, so make sure to run `npm install`
again on this branch.

This is integrated with the build, so if we introduce a JS issue in the
future it should show as an error on GitHub on the merge request.

For now I'm still ignoring 3 files I need to clean up (`bbcode.js`,
`forms.js` and `menus.js`) but the other have been fixed.

I used the [standard JS](https://standardjs.com/) set of rules which I
think are reasonable and not too strict, but I'm happy to discuss them
and relax some if needed.