### PR TITLE
Fixes #367: Fix insertion of game fact

### DIFF
--- a/Website/AtariLegend/php/admin/games/db_games_facts.php
+++ b/Website/AtariLegend/php/admin/games/db_games_facts.php
@@ -16,8 +16,6 @@ include("../../config/common.php");
 include("../../config/admin.php");
 include("../../config/admin_rights.php");
 
-echo $action;
-
 if ($action == "game_fact_insert") {
       
     if ($fact_text == '')


### PR DESCRIPTION
Remove debug comment that was left in, preventing the `Location` header
to be sent properly.