### PR TITLE
Website tables and backend cleanup

### DIFF
--- a/Website/AtariLegend/php/admin/administration/database_scripts/2017-12-12_website_category_parent.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2017-12-12_website_category_parent.php
@@ -1,0 +1,32 @@
+<?php
+/***************************************************************************
+ *   Update script to remove the unused `parent_category` column in website_category
+ *
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 125;
+
+// Description of what the change will do.
+$update_description = "Remove the website_category.parent_category column";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_success";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.columns
+WHERE table_schema = '$db_databasename'
+AND table_name = 'website_category'
+AND column_name = 'parent_category' LIMIT 1";
+
+// Database change
+$database_update_sql = "ALTER TABLE website_category DROP COLUMN parent_category";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2017-12-12_website_description-addition.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2017-12-12_website_description-addition.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * Additional upgrade script to transfer the website_description table contents
+ * into website.description, and then drop website_description
+ */
+
+$mysqli->query("ALTER TABLE website ADD description TEXT NULL")
+    or die("Couldn't add description column to website: ".$mysqli->error);
+
+$mysqli->query("UPDATE website
+    JOIN website_description ON website_description.website_id = website.website_id
+    SET website.description = website_description.website_description_text")
+    or die("Couldn't insert website descriptions: ".$mysqli->error);
+
+$mysqli->query("DROP TABLE website_description")
+    or die("Couldn't drop the website_description table: ".$mysqli->error) ;
+
+?>

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2017-12-12_website_description.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2017-12-12_website_description.php
@@ -1,0 +1,32 @@
+<?php
+/***************************************************************************
+ *   Update script to copy the website_description content into the website
+ *   table and drop the website_description table
+ *
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 124;
+
+// Description of what the change will do.
+$update_description = "Move the website descriptions inside the website table";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_success";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.tables
+WHERE table_schema = '$db_databasename'
+AND table_name = 'website_description' LIMIT 1";
+
+// Database change
+$database_update_sql = "../../admin/administration/database_scripts/2017-12-12_website_description-addition.php";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/links/link_mod.php
+++ b/Website/AtariLegend/php/admin/links/link_mod.php
@@ -27,7 +27,6 @@ include("../../config/admin.php");
 $smarty->assign('website_id', $website_id);
 
 $LINKSQL = $mysqli->query("SELECT * FROM website
-        LEFT JOIN website_description ON (website.website_id = website_description.website_id)
         WHERE website.website_id='$website_id'")
        or die("Error while querying the links database");
 
@@ -43,7 +42,7 @@ $smarty->assign('website', array(
     'website_url' => $rowlink['website_url'],
     'website_id' => $rowlink['website_id'],
 //  'category_id' => $rowlink['website_category_id'],
-    'website_description_text' => $rowlink['website_description_text'],
+    'website_description_text' => $rowlink['description'],
     'website_imgext' => $rowlink['website_imgext'],
     'inactive' => $rowlink['inactive'],
     'website_image' => $website_image));

--- a/Website/AtariLegend/php/admin/links/link_modlist.php
+++ b/Website/AtariLegend/php/admin/links/link_modlist.php
@@ -59,7 +59,6 @@ if (isset($catpick)) {
 }
 
 $LINKSQL = $mysqli->query("SELECT * FROM website
-                        LEFT JOIN website_description ON (website.website_id = website_description.website_id)
                         LEFT JOIN website_category_cross ON (website.website_id = website_category_cross.website_id)
                         WHERE website_category_cross.website_category_id=$website_category_id ORDER by website.website_name")
                         or die("Couldn't query website and website description");
@@ -76,7 +75,7 @@ while ($rowlink = $LINKSQL->fetch_array(MYSQLI_BOTH)) {
         'website_id' => $rowlink['website_id'],
         'website_name' => $rowlink['website_name'],
         'website_url' => $rowlink['website_url'],
-        'website_description' => $rowlink['website_description_text'],
+        'website_description' => $rowlink['description'],
         'website_image' => $website_image,
         'timestamp' => $timestamp,
         'submitted' => $submitted,

--- a/Website/AtariLegend/php/common/tiles/hotlinks_tile.php
+++ b/Website/AtariLegend/php/common/tiles/hotlinks_tile.php
@@ -22,13 +22,13 @@ $query_links = $mysqli->query("SELECT
 						website.website_url,
 						website.website_imgext,
                         website.website_date,
-						users.userid,
-						website_description.website_description_text
+                        website.website_date,
+                        website.description,
+						users.userid
 						FROM website
 						LEFT JOIN users ON ( website.user_id = users.user_id )
-						LEFT JOIN website_description ON ( website.website_id = website_description.website_id )
 						WHERE website.website_imgext <> ' '
-						ORDER BY RAND() LIMIT 1") or die("query error, hotlinks");
+						ORDER BY RAND() LIMIT 1") or die("query error, hotlinks: ".$mysqli->error);
 
 $sql_links = $query_links->fetch_array(MYSQLI_BOTH);
 
@@ -39,7 +39,7 @@ $v_link_image .= $sql_links['website_id'];
 $v_link_image .= '.';
 $v_link_image .= $sql_links['website_imgext'];
 
-$website_text = nl2br($sql_links['website_description_text']);
+$website_text = nl2br($sql_links['description']);
 $website_text = InsertALCode($website_text); // disabled this as it wrecked the design.
 $website_text = trim($website_text);
 $website_text = RemoveSmillies($website_text);


### PR DESCRIPTION
Move the website description inside a description column: To simplify
the schema and the code, just use a `description` column on `website`
rather than having a separate `website_description` table.

Remove the unused `parent_category` column (we do not support a tree
structure for categories anymore)

Fixed the website validation system that didn't work because of a
wrong `user_id` column name.