### PR TITLE
For #148: Create folders to hold the DB backups and public dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # exclude everything except directory data
-/Website/AtariLegend/data/
+/Website/AtariLegend/data/*
+!/Website/AtariLegend/data/database-*
 
 # exclude temporary directory where Smarty templates are compiled
 /Website/AtariLegend/php/temp

--- a/Website/AtariLegend/data/database-backups/.htaccess
+++ b/Website/AtariLegend/data/database-backups/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/Website/AtariLegend/data/database-dumps/.htaccess
+++ b/Website/AtariLegend/data/database-dumps/.htaccess
@@ -1,0 +1,4 @@
+Options +Indexes
+IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+HeaderName HEADER.html
+

--- a/Website/AtariLegend/data/database-dumps/HEADER.html
+++ b/Website/AtariLegend/data/database-dumps/HEADER.html
@@ -1,0 +1,7 @@
+<h1>AtariLegend daily database exports</h1>
+
+<p>The files below are daily exports of the AtariLegend database, minus the <code>users</code> table containing user accounts and passwords. The database is compatible with MySQL 5.x.</p>
+
+<p>The data can be used to build your own applications or generate reports.</p>
+
+<p><strong>LICENSE:</strong> TODO</p>


### PR DESCRIPTION
Create 2 folders to hold daily SQL dumps:
* `database-backups` will contain daily backups of the full database
* `database-dumps` will contain daily dumps of the full database minus
the `users` table (as we don't want to distribute password hashes)

Added relevant `.htaccess` files:
* Deny all access to the backups to prevent anyone from downloading the
files
* Display a list of available files for the dumps directory