### PR TITLE
Prevent search engines (Google, ...) to index the database dumps

### DIFF
--- a/Website/AtariLegend/robots.txt
+++ b/Website/AtariLegend/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Disallow: /admin/
+Disallow: /data/database-dumps/
 
 Sitemap: http://www.atarilegend.com/front/sitemap_index.php


### PR DESCRIPTION
I'm not sure they would download the DB and screenshot dumps, but it's
safer to disallow it.