### PR TITLE
Move all scripts at the bottom of the body in the frontend

### DIFF
--- a/Website/AtariLegend/themes/templates/1/main/about.html
+++ b/Website/AtariLegend/themes/templates/1/main/about.html
@@ -17,16 +17,23 @@
 {block name=title}The history of Atari Legend | Atari Legend{/block}
 {block name=description}Discover the history of the Atari Legend website from 1997 to today and the team behind it.{/block}
 
-{block name=main_body}
+{block name=additional_scripts}
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script>
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+
     <script>
         lightbox.option({
             'showImageNumberLabel': false
         })
     </script>
     <script src="{$template_dir}includes/js/vendor/modernizr-2.7.1.min.js"></script> <!-- Modernizr -->
+    <script src="{$template_dir}includes/js/about.js"></script>  <!-- jQuery script to animate the history blocks -->
+{/block}
 
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_games_details">
         <div class="content_box_games_details" id="column_left_interviews_details">
             {if isset($action) and $action == 'andreas'}
@@ -626,5 +633,4 @@
             {/block}
         </div>
     </div>
-    <script src="{$template_dir}includes/js/about.js"></script>  <!-- jQuery script to animate the history blocks -->
 {/block}

--- a/Website/AtariLegend/themes/templates/1/main/frontpage.html
+++ b/Website/AtariLegend/themes/templates/1/main/frontpage.html
@@ -23,9 +23,9 @@
 *}
 
 {block name=description}Find information, reviews and comments about Atari ST games, read interviews of famous Atari ST game developers, contribute missing information to the Atari Legend database.{/block}
-{block name=javascript_slider}
+{block name=additional_scripts}
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script>
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+
 
     <script>
         lightbox.option({
@@ -185,8 +185,8 @@
     </script>
     {/if}
     <script>
-        window.onload = function() {
-            $(".standard_list_entry_news_text").dotdotdot({  <!--This is the script to truncate the latest news-->
+        jQuery(document).ready(function () {
+            $(".standard_list_entry_news_text").dotdotdot({  // This is the script to truncate the latest news-->
                     //  configuration goes here
 
                 /*  The text to add as ellipsis. */
@@ -225,8 +225,12 @@
                     noEllipsis  : []
                 }
             });
-        };
+        });
     </script>
+{/block}
+
+{block name="additional_css"}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
 {/block}
 
 {block name=main_body}

--- a/Website/AtariLegend/themes/templates/1/main/games_comment_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_comment_main.html
@@ -19,7 +19,7 @@
 {extends file='1/main/main.html'}
 {block name=title}Latest Atari ST game comments | Atari Legend{/block}
 
-{block name=main_body}
+{block name=additional_scripts}
 
     {literal}
     <script>
@@ -135,6 +135,9 @@
         }
     </script>
     {/literal}
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_cpanel">
         <div class="content_box_cpanel" id="column_left_cpanel">
             <br>

--- a/Website/AtariLegend/themes/templates/1/main/games_detail.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_detail.html
@@ -20,7 +20,7 @@
 {extends file='1/main/main.html'}
 {block name=title}{$game_info.game_name} - Atari ST game | Atari Legend{/block}
 {block name=description}{$game_description}{/block}
-{block name=main_body}
+{block name=additional_scripts}
     <script src="{$template_dir}includes/js/vendor/jssor.slider-25.2.1.min.js"></script>
 
     <script> <!-- script used for the jquery screenshot and boxscan slider -->
@@ -169,17 +169,7 @@
     });
     </script>
 
-    <!-- I am adding a small piece of style code to make the thumbs bigger when there a less screenshots available, it makes it look better -->
-    <style>
-        {if $nr_screenshots < 10}
-            {literal}.games_main_detail_thumbs .p {width:160px;height:100px;}{/literal}
-        {else}
-            {literal}.games_main_detail_thumbs .p {width:90px;height:52px;}{/literal}
-        {/if}
-    </style>
-
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script>
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
 
     <script>
         lightbox.option({
@@ -547,8 +537,8 @@
 
     <script src="{$template_dir}includes/js/vendor/jquery.dotdotdot-1.8.3.min.js"></script> <!--this script is used for the elipsis (...) effect of the preview of the reviews -->
     <script>
-        window.onload = function() {
-            $(".game_details_review_preview_text").dotdotdot({  <!--This is the script to truncate the preview of the reviews-->
+        jQuery(document).ready(function () {
+            $(".game_details_review_preview_text").dotdotdot({  // This is the script to truncate the preview of the reviews-->
                     //  configuration goes here
 
                 /*  The text to add as ellipsis. */
@@ -587,7 +577,7 @@
                     noEllipsis  : []
                 }
             });
-        };
+        });
     </script>
     <script>
         $(function() {
@@ -607,7 +597,22 @@
             });
         });
     </script>
+{/block}
 
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+
+    <!-- I am adding a small piece of style code to make the thumbs bigger when there a less screenshots available, it makes it look better -->
+    <style>
+        {if $nr_screenshots < 10}
+            {literal}.games_main_detail_thumbs .p {width:160px;height:100px;}{/literal}
+        {else}
+            {literal}.games_main_detail_thumbs .p {width:90px;height:52px;}{/literal}
+        {/if}
+    </style>
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_games_details">
         <div class="content_box_games_details" id="column_left_games_details">
             <br>

--- a/Website/AtariLegend/themes/templates/1/main/games_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_main.html
@@ -18,7 +18,7 @@ The main game page
 {extends file='1/main/main.html'}
 {block name=title}Search and browse Atari ST games | Atari Legend{/block}
 
-{block name=main_body}
+{block name=additional_scripts}
     {literal}
     <script> <!-- script needed for the autocompletion search engine -->
         $(document).ready(function() {
@@ -143,6 +143,9 @@ The main game page
         cat_drop_text.style.display='none';
     }
     </script>
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_cpanel">
         <div class="content_box_cpanel" id="column_left_cpanel">
             <br>

--- a/Website/AtariLegend/themes/templates/1/main/games_main_list.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_main_list.html
@@ -22,7 +22,7 @@ The main game page
     {block name=title}Atari ST games search results | Atari Legend{/block}
 {/if}
 
-{block name=main_body}
+{block name=additional_scripts}
     {literal}
     <script> <!-- script needed for the autocompletion search engine -->
         $(document).ready(function() {
@@ -120,6 +120,9 @@ The main game page
         year_drop_text.style.display='none';
     }
     </script>
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_cpanel">
         <div class="content_box_cpanel" id="column_left_cpanel">
             <br>

--- a/Website/AtariLegend/themes/templates/1/main/games_reviews_add.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_reviews_add.html
@@ -18,10 +18,9 @@
 {extends file='1/main/main.html'}
 {block name=title}Add a review for {$game_info.game_name} (Atari ST) | Atari Legend{/block}
 
-{block name=main_body}
+{block name=additional_scripts}
     <!-- lightbox screenshot pop up script -->
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script>
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
 
     <script>
         lightbox.option({
@@ -280,6 +279,62 @@
     </script>
     <script src="{$template_dir}includes/js/vendor/jquery.dotdotdot-1.8.3.min.js"></script> <!--this script is used for the elipsis (...) effect of the latest reviews tile -->
 
+    <script>
+        jQuery(document).ready(function() {
+            $(".standard_list_entry_news_text").dotdotdot({  // This is the script to truncate the latest interviews
+                    //  configuration goes here
+
+                /*  The text to add as ellipsis. */
+                ellipsis    : '... ',
+
+                /*  How to cut off the text/html: 'word'/'letter'/'children' */
+                wrap        : 'word',
+
+                /*  Wrap-option fallback to 'letter' for long words */
+                fallbackToLetter: false,
+
+                /*  jQuery-selector for the element to keep and put after the ellipsis. */
+                after       : null,
+
+                /*  Whether to update the ellipsis: true/'window' */
+                watch       : window,
+
+                /*  Optionally set a max-height, can be a number or function.
+                    If null, the height will be measured. */
+                height      : null,
+
+                /*  Deviation for the height-option. */
+                tolerance   : 0,
+
+                /*  Callback function that is fired after the ellipsis is added,
+                    receives two parameters: isTruncated(boolean), orgContent(string). */
+                callback    : function( isTruncated, orgContent ) {},
+
+                lastCharacter   : {
+
+                    /*  Remove these characters from the end of the truncated text. */
+                    remove      : [ ' ', ',', ';', '.', '!', '?' ],
+
+                    /*  Don't add an ellipsis if this array contains
+                        the last character of the truncated text. */
+                    noEllipsis  : []
+                }
+            });
+        });
+    </script>
+    <script>
+        // Get the element with id="defaultOpen" and click on it
+        jQuery(document).ready(function () {
+            document.getElementById("defaultOpen").click();
+        });
+    </script>
+{/block}
+
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_games_details">
         <div class="content_box_games_details" id="column_left_reviews_details">
             <!--*****************************-->
@@ -503,57 +558,9 @@
             {else}
                 <br>
                 {include file='1/main/latest_comments_tile.html'}
-
-                <script>
-                window.onload = function() {
-                    $(".standard_list_entry_news_text").dotdotdot({  <!--This is the script to truncate the latest interviews-->
-                            //  configuration goes here
-
-                        /*  The text to add as ellipsis. */
-                        ellipsis    : '... ',
-
-                        /*  How to cut off the text/html: 'word'/'letter'/'children' */
-                        wrap        : 'word',
-
-                        /*  Wrap-option fallback to 'letter' for long words */
-                        fallbackToLetter: false,
-
-                        /*  jQuery-selector for the element to keep and put after the ellipsis. */
-                        after       : null,
-
-                        /*  Whether to update the ellipsis: true/'window' */
-                        watch       : window,
-
-                        /*  Optionally set a max-height, can be a number or function.
-                            If null, the height will be measured. */
-                        height      : null,
-
-                        /*  Deviation for the height-option. */
-                        tolerance   : 0,
-
-                        /*  Callback function that is fired after the ellipsis is added,
-                            receives two parameters: isTruncated(boolean), orgContent(string). */
-                        callback    : function( isTruncated, orgContent ) {},
-
-                        lastCharacter   : {
-
-                            /*  Remove these characters from the end of the truncated text. */
-                            remove      : [ ' ', ',', ';', '.', '!', '?' ],
-
-                            /*  Don't add an ellipsis if this array contains
-                                the last character of the truncated text. */
-                            noEllipsis  : []
-                        }
-                    });
-                };
-                </script>
             {/if}
             <br>
             {include file='1/main/tile_bug_report.html'}
         </div>
     </div>
-    <script>
-        // Get the element with id="defaultOpen" and click on it
-        document.getElementById("defaultOpen").click();
-    </script>
 {/block}

--- a/Website/AtariLegend/themes/templates/1/main/games_reviews_detail.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_reviews_detail.html
@@ -17,10 +17,9 @@
 
 {extends file='1/main/main.html'}
 {block name=title}{$review.game_name} review (Atari ST) | Atari Legend{/block}
-{block name=main_body}
+{block name=additional_scripts}
     <!-- lightbox screenshot pop up script -->
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script>
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
 
     <script>
         lightbox.option({
@@ -306,8 +305,8 @@
 
     <script src="{$template_dir}includes/js/vendor/jquery.dotdotdot-1.8.3.min.js"></script> <!--this script is used for the elipsis (...) effect of the latest reviews tile -->
     <script>
-        window.onload = function() {
-            $(".standard_list_entry_news_text").dotdotdot({  <!--This is the script to truncate the latest interviews-->
+        jQuery(document).ready(function () {
+            $(".standard_list_entry_news_text").dotdotdot({  // This is the script to truncate the latest interviews-->
                 //  configuration goes here
 
             /*  The text to add as ellipsis. */
@@ -346,9 +345,15 @@
                 noEllipsis  : []
             }
         });
-    };
+    });
     </script>
+{/block}
 
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_games_details">
         <div class="content_box_games_details" id="column_left_reviews_details">
 

--- a/Website/AtariLegend/themes/templates/1/main/games_reviews_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_reviews_main.html
@@ -17,11 +17,11 @@
 {extends file='1/main/main.html'}
 {block name=title}Latest Atari ST game reviews | Atari Legend{/block}
 
-{block name=main_body}
+{block name=additional_scripts}
     <script src="{$template_dir}includes/js/vendor/jquery.dotdotdot-1.8.3.min.js"></script> <!--this script is used for the elipsis (...) effect of the preview of the reviews -->
     <script>
-        window.onload = function() {
-            $(".interview_main_text").dotdotdot({  <!--This is the script to truncate the preview of the reviews-->
+        jQuery(document).ready(function () {
+            $(".interview_main_text").dotdotdot({  // This is the script to truncate the preview of the reviews-->
                     //  configuration goes here
 
                 /*  The text to add as ellipsis. */
@@ -60,17 +60,22 @@
                     noEllipsis  : []
                 }
             });
-        };
+        });
     </script>
 
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script><!--lightbox popup script-->
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
     <script>
         lightbox.option({
             'showImageNumberLabel': false
         })
     </script>
+{/block}
 
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
+{block name=main_body}
     <div id="main" class="main_container_cpanel">
         <div class="content_box_cpanel" id="column_left_cpanel">
             <br>

--- a/Website/AtariLegend/themes/templates/1/main/interviews_detail.html
+++ b/Website/AtariLegend/themes/templates/1/main/interviews_detail.html
@@ -20,10 +20,9 @@
 {extends file='1/main/main.html'}
 {block name=title}Interview of {$interview.individual_name} ({$interview.interview_year}) | Atari Legend{/block}
 
-{block name=main_body}
+{block name=additional_scripts}
     <!-- lightbox screenshot pop up script -->
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script>
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
 
     <script>
         lightbox.option({
@@ -309,8 +308,8 @@
 
     <script src="{$template_dir}includes/js/vendor/jquery.dotdotdot-1.8.3.min.js"></script> <!--this script is used for the elipsis (...) effect of the latest interviews tile -->
     <script>
-        window.onload = function() {
-            $(".standard_list_entry_news_text").dotdotdot({  <!--This is the script to truncate the latest interviews-->
+        jQuery(document).ready(function () {
+            $(".standard_list_entry_news_text").dotdotdot({  // This is the script to truncate the latest interviews-->
                     //  configuration goes here
 
                 /*  The text to add as ellipsis. */
@@ -349,9 +348,16 @@
                     noEllipsis  : []
                 }
             });
-        };
+        });
     </script>
+{/block}
 
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
+
+{block name=main_body}
     <div id="main" class="main_container_games_details">
         <div class="content_box_games_details" id="column_left_interviews_details">
             <!--*****************************-->

--- a/Website/AtariLegend/themes/templates/1/main/interviews_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/interviews_main.html
@@ -17,11 +17,11 @@
 {extends file='1/main/main.html'}
 {block name=title}Latest Atari ST interviews | Atari Legend{/block}
 
-{block name=main_body}
+{block name=additional_scripts}
     <script src="{$template_dir}includes/js/vendor/jquery.dotdotdot-1.8.3.min.js"></script> <!--this script is used for the elipsis (...) effect of the preview of the reviews -->
     <script>
-        window.onload = function() {
-            $(".interview_main_text").dotdotdot({  <!--This is the script to truncate the preview of the reviews-->
+        jQuery(document).ready(function () {
+            $(".interview_main_text").dotdotdot({  // This is the script to truncate the preview of the reviews-->
                     //  configuration goes here
 
                 /*  The text to add as ellipsis. */
@@ -60,17 +60,22 @@
                     noEllipsis  : []
                 }
             });
-        };
+        });
     </script>
 
     <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script><!--lightbox popup script-->
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
     <script>
         lightbox.option({
             'showImageNumberLabel': false
         })
     </script>
+{/block}
 
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
+{block name=main_body}}
     <div id="main" class="main_container_cpanel">
         <div class="content_box_cpanel" id="column_left_cpanel">
             <br>

--- a/Website/AtariLegend/themes/templates/1/main/links_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/links_main.html
@@ -5,6 +5,19 @@
     {block name=title}Atari ST links and resources | Atari Legend{/block}
 {/if}
 
+{block name=additional_scripts}
+    <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script><!--lightbox popup script-->
+    <script>
+        lightbox.option({
+            'showImageNumberLabel': false
+        })
+    </script>
+{/block}
+
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
 {block name=main_body}
     <div id="main" class="main_container_cpanel">
         <div class="content_box_cpanel" id="column_left_cpanel">
@@ -89,11 +102,4 @@
             {include file='1/main/did_you_know_tile.html'}
         </div>
     </div>
-    <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script><!--lightbox popup script-->
-    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
-    <script>
-        lightbox.option({
-            'showImageNumberLabel': false
-        })
-    </script>
 {/block}

--- a/Website/AtariLegend/themes/templates/1/main/main.html
+++ b/Website/AtariLegend/themes/templates/1/main/main.html
@@ -40,7 +40,8 @@
         <link rel="apple-touch-icon" sizes="144x144" href="{$template_dir}includes/icons/icon-144x144.png">
         <!-- end - get the icons used for mobile devices -->
 
-        <script src="{$template_dir}includes/js/vendor/jquery-2.1.4.min.js"></script> <!-- main jquery stuff -->
+        {* Inner page can inject additional CSS that gets put here *}
+        {block name=additional_css}{/block}
 
         {* Insert Google Analytics tags only on production *}
         {if $smarty.server.HTTP_HOST == $smarty.const.SITEHOST}
@@ -222,6 +223,7 @@
         <script src="{$template_dir}includes/js/vendor/md5-1.0.1.min.js"></script>  <!-- log on security script -->
         <script src="{$template_dir}includes/js/vendor/sha512-2.2.min.js"></script> <!-- log on security script -->
         <script src="{$template_dir}includes/js/vendor/respond-1.1.0.min.js"></script> <!-- script needed for the side menu -->
+        <script src="{$template_dir}includes/js/vendor/jquery-2.1.4.min.js"></script> <!-- main jquery stuff -->
         <script src="{$template_dir}includes/js/vendor/jquery-ui-1.11.4.min.js"></script> <!-- main jqueryUI stuff -->
         <script src="{$template_dir}includes/js/vendor/notify-osd-51f8de7.min.js"></script>
 
@@ -242,5 +244,8 @@
 
         <script src="{$template_dir}includes/js/forms.js"></script> <!-- log on security script -->
         <script src="{$template_dir}includes/js/main.js"></script>
+
+        {* Inner pages can inject additional JS that gets put here, after jQuery is included *}
+        {block name=additional_scripts}{/block}
     </body>
 </html>

--- a/Website/AtariLegend/themes/templates/1/main/tile_changes_per_month.html
+++ b/Website/AtariLegend/themes/templates/1/main/tile_changes_per_month.html
@@ -17,7 +17,7 @@
 *}
 <script src="{$template_dir}includes/js/vendor/Chart-2.5.0.min.js"></script> <!-- chart creation -->
 <script>
-window.onload = function () {
+jQuery(document).ready(function () {
 
     var data_cl_monthly = {$change_log_monthly_data};
     var labels_cl_monthly = {$change_log_monthly_label};
@@ -48,7 +48,7 @@ window.onload = function () {
             }
         }
     })
-};
+});
 </script>
 
 <div class="standard_tile">


### PR DESCRIPTION
Created an `additional_scripts` Smarty block that pages can use to
inject additional scripts at the end of the body. That will ensure that
all scripts used everywhere are always loaded last and don't delay the
display of the page. In turns that allows us to finally move jQuery at
the bottom of the body for faster loading.

Did the same for the CSS with `additional_css`, to remove random
`<link>` tags that got inserted in the middle of the page (where they
should be in the `<head>`).

Aside: Minor JS fixes due to confusion between the HTML comment tag
`<!--` and the JS one `//` inside `<script>` blocks.

Aside: Replaced `window.onload` with `jQuery(document).ready()` that
looks more reliable (sometimes `window.onload` didn't fire for me and
dotdotdot wouldn't apply).