### PR TITLE
Remove the "Parent directory" link at the top of the DB dumps list

### DIFF
--- a/Website/AtariLegend/data/database-dumps/.htaccess
+++ b/Website/AtariLegend/data/database-dumps/.htaccess
@@ -1,5 +1,5 @@
 Options +Indexes
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t ..
 HeaderName HEADER.html
 IndexOptions NameWidth=*
 AddDescription "MySQL database dump" *.sql.gz


### PR DESCRIPTION
The "Parent directory" link just points to `/data/` where there's
nothing to see (it was reported as an error by the Google Search
Console).