### PR TITLE
Run PHP CodeSniffer by default when building

### DIFF
--- a/.phpcs-ruleset.xml
+++ b/.phpcs-ruleset.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Standard" namespace="MyProject\CS\Standard">
+	<rule ref="PSR2">
+		<!-- Disable putting function braces on a new line -->
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine" />
+		<!-- Disable puttin class braces on a new line -->
+		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine" />
+		<!-- Prevent warning for classes that use require_once() -->
+		<exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
+		<!-- Allow multiple arguments on the same line when calling functions -->
+		<exclude name="PSR2.Methods.FunctionCallSignature.MultipleArguments" />
+	</rule>
+	<!-- Ensure functions braces are on the same line -->
+	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+</ruleset>

--- a/Docker/php/Dockerfile
+++ b/Docker/php/Dockerfile
@@ -14,3 +14,5 @@ RUN a2enmod expires
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
 RUN apt-get install -y build-essential
+
+RUN pear install PHP_CodeSniffer

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,19 +132,26 @@ module.exports = function (grunt) {
                     '<%= webRoot %>php/**/*.php',
                     '!<%= webRoot %>php/{temp,vendor}/**/*.php'
                 ],
-                tasks: ['phpcs']
+                tasks: ['phpcs:all']
             }
         },
 
         phpcs: {
             application: {
                 src: [
+                    '<%= webRoot %>php/common/DAO/**/*.php',
+                    '<%= webRoot %>php/common/Model/**/*.php',
+                    '<%= webRoot %>php/lib/Db.php'
+                ]
+            },
+            all: {
+                src: [
                     '<%= webRoot %>php/**/*.php',
                     '!<%= webRoot %>php/{temp,vendor}/**/*.php'
                 ]
             },
             options: {
-                standard: 'PSR2',
+                standard: '.phpcs-ruleset.xml',
                 severity: 3
             }
         },
@@ -212,11 +219,11 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-php-cs-fixer');
 
     // Default task(s).
-    grunt.registerTask('default', ['eslint:application', 'lintspaces', 'sass', 'pleeease']);
+    grunt.registerTask('default', ['eslint:application', 'lintspaces', 'sass', 'pleeease', 'phpcs:application']);
     grunt.registerTask('lint', ['scsslint']);
     grunt.registerTask('sass-lint', ['sasslint']);
     grunt.registerTask('css-fix', ['csscomb']);
-    grunt.registerTask('phpcheck', ['phpcs']);
+    grunt.registerTask('phpcheck', ['phpcs:all']);
     grunt.registerTask('phpfixer', ['phpcbf']);
     grunt.registerTask('phpfix', ['phpcsfixer']);
 };

--- a/Website/AtariLegend/php/common/DAO/LinkCategoryDAO.php
+++ b/Website/AtariLegend/php/common/DAO/LinkCategoryDAO.php
@@ -29,7 +29,8 @@ class LinkCategoryDAO {
                 COUNT(website_category_cross_id)
             FROM
                 website_category
-            LEFT JOIN website_category_cross ON website_category.website_category_id = website_category_cross.website_category_id
+            LEFT JOIN website_category_cross
+                ON website_category.website_category_id = website_category_cross.website_category_id
             GROUP BY
                 website_category.website_category_id
             ORDER BY
@@ -56,7 +57,7 @@ class LinkCategoryDAO {
     /**
      * Retrieve a specific category
      *
-     * @param integer $category_id ID of the category to retrieve
+     * @param  integer $category_id ID of the category to retrieve
      * @return AL\Common\Model\Link\LinkCategory Category
      */
     public function getCategory($category_id) {

--- a/Website/AtariLegend/php/common/DAO/LinkDAO.php
+++ b/Website/AtariLegend/php/common/DAO/LinkDAO.php
@@ -8,17 +8,17 @@ require_once __DIR__."/../Model/Link/Link.php" ;
  * DAO for Links
  */
 class LinkDAO {
-    private $_mysqli;
+    private $mysqli;
 
     public function __construct($mysqli) {
-        $this->_mysqli = $mysqli;
+        $this->mysqli = $mysqli;
     }
 
     /**
      * Get the SQL query to retrieve links, either all links or links for a
      * specific category
      *
-     * @param integer $category_id Optional ID of the category to retrieve links for
+     * @param  integer $category_id Optional ID of the category to retrieve links for
      * @return string SQL query
      */
     private function getLinkQuery($category_id = null) {
@@ -36,13 +36,16 @@ class LinkDAO {
                 website_category_name
             FROM
                 website
-            LEFT JOIN website_category_cross ON website_category_cross.website_id = website.website_id
-            LEFT JOIN website_category ON website_category.website_category_id = website_category_cross.website_category_id
-            LEFT JOIN users ON users.user_id = website.user_id";
+            LEFT JOIN website_category_cross
+                ON website_category_cross.website_id = website.website_id
+            LEFT JOIN website_category
+                ON website_category.website_category_id = website_category_cross.website_category_id
+            LEFT JOIN users
+                ON users.user_id = website.user_id";
 
         if (isset($category_id)) {
             $query .= " WHERE website_category.website_category_id = ?";
-    }
+        }
 
         $query .= " ORDER BY website_date DESC LIMIT ?, ?";
 
@@ -52,14 +55,14 @@ class LinkDAO {
     /**
      * Retrieve all links
      *
-     * @param integer $offset Link offset to start with, for paging
-     * @param integer $limit How many links to return, for paging
+     * @param  integer $offset Link offset to start with, for paging
+     * @param  integer $limit  How many links to return, for paging
      * @return \AL\Common\Model\Link\Link[] An array of links
      */
     public function getAllLinks($offset = 0, $limit = 5) {
         $stmt = \AL\Db\execute_query(
             "LinkDAO: Get all links",
-            $this->_mysqli,
+            $this->mysqli,
             $this->getLinkQuery(),
             "ii", $offset, $limit
         );
@@ -72,7 +75,17 @@ class LinkDAO {
 
         $links = [];
         while ($stmt->fetch()) {
-            $links[] = new \AL\Common\Model\Link\Link($id, $name, $url, $description, $imgext, $inactive, $user, $date, $userid);
+            $links[] = new \AL\Common\Model\Link\Link(
+                $id,
+                $name,
+                $url,
+                $description,
+                $imgext,
+                $inactive,
+                $user,
+                $date,
+                $userid
+            );
         }
 
         $stmt->close();
@@ -83,15 +96,15 @@ class LinkDAO {
     /**
      * Retrieve all links for a category
      *
-     * @param integer $category_id ID of the category to retrieve links for
-     * @param integer $offset Link offset to start with, for paging
-     * @param ingeter $limit How many links to return, for paging
+     * @param  integer $category_id ID of the category to retrieve links for
+     * @param  integer $offset      Link offset to start with, for paging
+     * @param  ingeter $limit       How many links to return, for paging
      * @return \AL\Common\Model\Link\Link[] An array of links
      */
     public function getAllLinksForCategory($category_id, $offset = 0, $limit = 5) {
         $stmt = \AL\Db\execute_query(
             "LinkDAO: Get all links",
-            $this->_mysqli,
+            $this->mysqli,
             $this->getLinkQuery($category_id),
             "iii", $category_id, $offset, $limit
         );
@@ -99,12 +112,32 @@ class LinkDAO {
         \AL\Db\bind_result(
             "LinkDAO: Get all links",
             $stmt,
-            $id, $name, $url, $description, $imgext, $inactive, $user, $userid, $date, $category_id, $category_name
+            $id,
+            $name,
+            $url,
+            $description,
+            $imgext,
+            $inactive,
+            $user,
+            $userid,
+            $date,
+            $category_id,
+            $category_name
         );
 
         $links = [];
         while ($stmt->fetch()) {
-            $links[] = new \AL\Common\Model\Link\Link($id, $name, $url, $description, $imgext, $inactive, $user, $date, $userid);
+            $links[] = new \AL\Common\Model\Link\Link(
+                $id,
+                $name,
+                $url,
+                $description,
+                $imgext,
+                $inactive,
+                $user,
+                $date,
+                $userid
+            );
         }
 
         $stmt->close();
@@ -115,21 +148,21 @@ class LinkDAO {
     /**
      * Get the total count of links, for all links or for a given category
      *
-     * @param integer $category_id Optional ID of a category to count links for
+     * @param  integer $category_id Optional ID of a category to count links for
      * @return integer Number of links
      */
     public function getLinkCount($category_id = null) {
         if (isset($category_id)) {
             $stmt = \AL\Db\execute_query(
                 "LinkDAO: Get link count for category $category_id",
-                $this->_mysqli,
+                $this->mysqli,
                 "SELECT COUNT(*) FROM website_category_cross WHERE website_category_id = ?",
                 "i", $category_id
             );
         } else {
             $stmt = \AL\Db\execute_query(
                 "LinkDAO: Get link count",
-                $this->_mysqli,
+                $this->mysqli,
                 "SELECT COUNT(*) FROM website".
                 null, null
             );
@@ -146,14 +179,14 @@ class LinkDAO {
 
         return $count;
     }
-    
+
     /**
      * Get a random link
-    */
+     */
     public function getRandomLink() {
         $stmt = \AL\Db\execute_query(
             "LinkDAO: Get random link",
-            $this->_mysqli,
+            $this->mysqli,
             "SELECT website.website_id,
                     website.website_name,
                     website.website_url,
@@ -171,20 +204,36 @@ class LinkDAO {
         );
 
         \AL\Db\bind_result(
-             "LinkDAO: Get random link",
+            "LinkDAO: Get random link",
             $stmt,
-            $id, $name, $url, $imgext, $date, $description, $inactive, $user, $userid
+            $id,
+            $name,
+            $url,
+            $imgext,
+            $date,
+            $description,
+            $inactive,
+            $user,
+            $userid
         );
 
         $link = null;
         if ($stmt->fetch()) {
-            $link = new \AL\Common\Model\Link\Link($id, $name, $url, $description, $imgext, $inactive, $user, $date, $userid);
+            $link = new \AL\Common\Model\Link\Link(
+                $id,
+                $name,
+                $url,
+                $description,
+                $imgext,
+                $inactive,
+                $user,
+                $date,
+                $userid
+            );
         }
 
         $stmt->close();
 
         return $link;
     }
-
 }
-

--- a/Website/AtariLegend/php/common/DAO/ValidateLinkDAO.php
+++ b/Website/AtariLegend/php/common/DAO/ValidateLinkDAO.php
@@ -7,24 +7,24 @@ require_once __DIR__."/../../lib/Db.php" ;
  * DAO for links submitted by users that need to be validated
  */
 class ValidateLinkDAO {
-    private $_mysqli;
+    private $mysqli;
 
     public function __construct($mysqli) {
-        $this->_mysqli = $mysqli;
+        $this->mysqli = $mysqli;
     }
 
     /**
      * Add a new link to validate
      *
-     * @param string $name Name of the link
-     * @param string $url URL of the link
-     * @param string $description Description of the link
+     * @param  string $name        Name of the link
+     * @param  string $url         URL of the link
+     * @param  string $description Description of the link
      * @return integer ID of the inserted link to validate
      */
     public function addValidateLink($name, $url, $description) {
         $stmt = \AL\Db\execute_query(
             "ValidateLinkDAO: Add link",
-            $this->_mysqli,
+            $this->mysqli,
             "INSERT INTO website_validate (
                 website_name,
                 website_url,

--- a/Website/AtariLegend/php/common/Model/Link/Link.php
+++ b/Website/AtariLegend/php/common/Model/Link/Link.php
@@ -55,7 +55,7 @@ class Link {
     public function getUser() {
         return $this->user;
     }
-    
+
     public function getUserId() {
         return $this->userid;
     }

--- a/Website/AtariLegend/php/common/Model/Link/LinkCategory.php
+++ b/Website/AtariLegend/php/common/Model/Link/LinkCategory.php
@@ -26,5 +26,4 @@ class LinkCategory {
     public function getCount() {
         return $this->count;
     }
-
 }

--- a/Website/AtariLegend/php/lib/Db.php
+++ b/Website/AtariLegend/php/lib/Db.php
@@ -5,7 +5,7 @@ namespace AL\Db;
 /**
  * Get an error context message
  *
- * @param $context Human friendly context message
+ * @param  $context Human friendly context message
  * @return An error context string
  */
 function get_error_context($context) {
@@ -15,14 +15,14 @@ function get_error_context($context) {
 /**
  * Prepare a statement for the given query and parameters and handle errors
  *
- * @param $context A human-friendly string giving the context the query is running
+ * @param  $context A human-friendly string giving the context the query is running
  *  in. This will be output in error messages if something goes wrong
- * @param $mysqli Database connection
- * @param $query The SQL query to execute, using ? placeholders for parameters
- * @param $bind_string The string representing the types of parameters to bind
+ * @param  $mysqli Database connection
+ * @param  $query The SQL query to execute, using ? placeholders for parameters
+ * @param  $bind_string The string representing the types of parameters to bind
  *  (See mysqli_bind_param()), e.g. "ss" for 2 strings. Pass NULL if the query
  *  doesn't have parameters
- * @param $params The list of parameters to bind. Pass NULL if the query doesn't
+ * @param  $params The list of parameters to bind. Pass NULL if the query doesn't
  *  have parameters
  * @return A prepared statement that has been executed
  */
@@ -32,10 +32,10 @@ function execute_query($context, $mysqli, $query, $bind_string, ...$params) {
     $stmt = $mysqli->prepare($query)
         or die("Error preparing query [$query] $err_ctx: ".$mysqli->error);
 
-    if ($bind_string !== NULL) {
+    if ($bind_string !== null) {
         $stmt->bind_param($bind_string, ...$params)
             or die("Error binding parameters $err_ctx");
-    } else if (strstr($query, "?")) {
+    } elseif (strstr($query, "?")) {
         die("Error: The query [$query] contained parameters (?) but didn't have a bind string $err_ctx");
     }
 


### PR DESCRIPTION
Run PHP CS on new files on the default build task, for now ignoring the
old ones (as there are too many errors to fix). Ideally everytime we add
a new PHP file we should update the Grunt config to include it in the
PHP CS task, to ensure that we don't continue to introduce syntax
violation on new code.

I kept the manual task `grunt phpcs` to check all files, not just the
new ones, in case someone feels brave enough to start fixing old files
:wink:

For now enabled it by default for `common/DAO/`, `common/Model/` and
`lib/Db.php` which are likely to be expanded as we add new DAO and Model
classes.

Tweaked the ruleset a bit, mostly to do with braces and a couple of
other minor things.

Updated the Docker image to install PHP CS so that Shippable can run it.