### PR TITLE
Added cache headers to image wrapper

### DIFF
--- a/Website/AtariLegend/php/includes/show_image.php
+++ b/Website/AtariLegend/php/includes/show_image.php
@@ -111,5 +111,14 @@ if (isset($minimum_width) or isset($minimum_height)) {
         $image = $image->resize($minimum_width, $minimum_height, 'fill', 'up');
     }
 }
+
+// Send LMD and cache headers to have the browser cache the file,
+// which should never change
+$filedate = filemtime($file_path);
+// Use @ to avoid any possible warnings related to timezone if the PHP
+// host is misconfigured
+@header("Last-Modified: ".date("D, d M Y G:i:s T", $filedate));
+header("Cache-Control: max-age=157680000");
+
 //set the compression in the config.php file
-$image->output('jpg', "$jpeg_compression");
+$image->output('jpg', $jpeg_compression);


### PR DESCRIPTION
My understanding is that images served via the image wrapper will never
change because they are tied to a specific ID in the database (so if
there's a new image, the old ID is deleted and there's a new one
generated for the new image).

That means that we can aggressively cache the image served by the image
wrapper since they will never change. Do that by adding a last modified
date and cache control header. That should help with page speed loading.