### PR TITLE
Fix a couple of issues following moving the scripts at the bottom

### DIFF
--- a/Website/AtariLegend/themes/templates/1/main/games_main_list.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_main_list.html
@@ -120,6 +120,71 @@ The main game page
         year_drop_text.style.display='none';
     }
     </script>
+
+    <!--This is the lazy load script with fader effect - fader is pure css class -->
+    <script src="{$template_dir}includes/js/vendor/lazyload-8.0.1.min.js"></script>
+    <script>
+    (function () {
+        var ll = new LazyLoad({
+            threshold: 0
+        });
+    }());
+    </script>
+    <!--end lazy load script with fader effect -->
+
+    {if isset($export) and ($export == 'export')}
+        <script src="{$template_dir}includes/js/vendor/tabulator-3.2.x.min.js"></script> <!-- tabulator script -->
+        <script src="{$template_dir}includes/js/vendor/xlsx.full-0.10.6.min.js"></script> <!-- export to xlsx script -->
+        <script>
+        //define some sample data
+        var tabledata = {$data};
+
+        {literal}
+
+            //create Tabulator on DOM element with id "example-table"
+            $("#games-table").tabulator({
+                responsiveLayout:true, // this option takes a boolean value (default = false)
+                fitColumns:true,
+                pagination:"local",
+                columns:[ //Define Table Columns
+                    {title:"Name", field:"game_name", sorter:"string", align:"left", headerFilter:"input", minWidth:150, responsive:0,cellClick:function(e, cell){window.location="../games/games_detail.php?game_id=" + cell.getRow().getData().game_id}},
+                    {title:"Publisher", field:"publisher_name", sorter:"string", align:"left", headerFilter:"input", minWidth:150, cellClick:function(e, cell){window.location="../games/games_main_list.php?publisher=" + cell.getRow().getData().publisher_id + "&action=search&export=1"}},
+                    {title:"Developer", field:"developer_name", sorter:"string", align:"left", headerFilter:"input", minWidth:150, cellClick:function(e, cell){window.location="../games/games_main_list.php?developer=" + cell.getRow().getData().developer_id + "&action=search&export=1"}},
+                    {title:"Year", field:"year", sorter:"string", align:"left",headerFilter:"input", width:75, minWidth:50, cellClick:function(e, cell){window.location="../games/games_main_list.php?year=" + cell.getRow().getData().year + "&action=search&export=1"}},
+                    {title:"Boxscan", field:"boxscan", sorter:"string", formatter:"tickCross",headerFilter:"input", width:100, minWidth:50},
+                    {title:"Screenshot", field:"screenshot", sorter:"string", formatter:"tickCross",headerFilter:"input", width:120, minWidth:50},
+                    {title:"Download", field:"download", sorter:"string", formatter:"tickCross",headerFilter:"input", width:110, minWidth:50},
+                    {title:"Music", field:"music", sorter:"string", formatter:"tickCross",headerFilter:"input", width:75, minWidth:50},
+                ],
+            });
+            $("#games-table").tabulator("setPageSize", 25); // show 25 rows per page
+
+            //trigger download of data.csv file
+            $("#download-csv").click(function(){
+                $("#games-table").tabulator("download", "csv", "data.csv");
+            });
+
+            //trigger download of data.json file
+            $("#download-json").click(function(){
+                $("#games-table").tabulator("download", "json", "data.json");
+            });
+
+            //trigger download of data.xlsx file
+            $("#download-xlsx").click(function(){
+                $("#games-table").tabulator("download", "xlsx", "data.xlsx");
+            });
+
+            //load sample data into the table
+            $("#games-table").tabulator("setData", tabledata);
+
+            $(window).on('resize', function () {
+                $(".tabulator").tabulator("redraw");
+            });
+
+        {/literal}
+        </script>
+    {/if}
+
 {/block}
 
 {block name=main_body}
@@ -133,10 +198,6 @@ The main game page
         <div class="content_box_cpanel" id="column_center_cpanel">
             <br>
             {if isset($export) and ($export == 'export')}
-
-            <!-- for tabulator this script needs to be loaded first. I have added this one within the EXPORT IF statement. Normally this thing is called at the
-                bottom of the page (to speed up the site), in case of the export mode we have to make a difference. More details see #405 on GITHUB -->
-            <script src="{$template_dir}includes/js/vendor/jquery-ui-1.11.4.min.js"></script> <!-- main jqueryUI stuff -->
 
             <div class="standard_tile" id="games_main">
                 <div class="help-tip">
@@ -166,56 +227,7 @@ The main game page
                         <b>{if $nr_of_games == 1}1 game found {else} {$nr_of_games} games found{/if} in {$query_time} sec</b>
                     </div>
                 </div>
-                <script src="{$template_dir}includes/js/vendor/tabulator-3.2.x.min.js"></script> <!-- tabulator script -->
-                <script src="{$template_dir}includes/js/vendor/xlsx.full-0.10.6.min.js"></script> <!-- export to xlsx script -->
-                <script>
-                //define some sample data
-                var tabledata = {$data};
 
-                {literal}
-
-                //create Tabulator on DOM element with id "example-table"
-                $("#games-table").tabulator({
-                    responsiveLayout:true, // this option takes a boolean value (default = false)
-                    fitColumns:true,
-                    pagination:"local",
-                    columns:[ //Define Table Columns
-                        {title:"Name", field:"game_name", sorter:"string", align:"left", headerFilter:"input", minWidth:150, responsive:0,cellClick:function(e, cell){window.location="../games/games_detail.php?game_id=" + cell.getRow().getData().game_id}},
-                        {title:"Publisher", field:"publisher_name", sorter:"string", align:"left", headerFilter:"input", minWidth:150, cellClick:function(e, cell){window.location="../games/games_main_list.php?publisher=" + cell.getRow().getData().publisher_id + "&action=search&export=1"}},
-                        {title:"Developer", field:"developer_name", sorter:"string", align:"left", headerFilter:"input", minWidth:150, cellClick:function(e, cell){window.location="../games/games_main_list.php?developer=" + cell.getRow().getData().developer_id + "&action=search&export=1"}},
-                        {title:"Year", field:"year", sorter:"string", align:"left",headerFilter:"input", width:75, minWidth:50, cellClick:function(e, cell){window.location="../games/games_main_list.php?year=" + cell.getRow().getData().year + "&action=search&export=1"}},
-                        {title:"Boxscan", field:"boxscan", sorter:"string", formatter:"tickCross",headerFilter:"input", width:100, minWidth:50},
-                        {title:"Screenshot", field:"screenshot", sorter:"string", formatter:"tickCross",headerFilter:"input", width:120, minWidth:50},
-                        {title:"Download", field:"download", sorter:"string", formatter:"tickCross",headerFilter:"input", width:110, minWidth:50},
-                        {title:"Music", field:"music", sorter:"string", formatter:"tickCross",headerFilter:"input", width:75, minWidth:50},
-                    ],
-                });
-                $("#games-table").tabulator("setPageSize", 25); // show 25 rows per page
-
-                //trigger download of data.csv file
-                $("#download-csv").click(function(){
-                    $("#games-table").tabulator("download", "csv", "data.csv");
-                });
-
-                //trigger download of data.json file
-                $("#download-json").click(function(){
-                    $("#games-table").tabulator("download", "json", "data.json");
-                });
-
-                //trigger download of data.xlsx file
-                $("#download-xlsx").click(function(){
-                    $("#games-table").tabulator("download", "xlsx", "data.xlsx");
-                });
-
-                //load sample data into the table
-                $("#games-table").tabulator("setData", tabledata);
-
-                $(window).on('resize', function () {
-                    $(".tabulator").tabulator("redraw");
-                });
-
-                {/literal}
-                </script>
             </div>
             {else}
                 <div class="standard_tile" id="games_main">
@@ -553,16 +565,6 @@ The main game page
                 </div>
             {/if}
             <br>
-            <!--This is the lazy load script with fader effect - fader is pure css class -->
-            <script src="{$template_dir}includes/js/vendor/lazyload-8.0.1.min.js"></script>
-            <script>
-            (function () {
-                var ll = new LazyLoad({
-                    threshold: 0
-                });
-            }());
-            </script>
-            <!--end lazy load script with fader effect -->
             <div class="standard_tile_text_center"><a href="javascript:history.go(-1)" class="standard_tile_link">back</a></div>
         </div>
         <div class="content_box_cpanel" id="column_right_cpanel">

--- a/Website/AtariLegend/themes/templates/1/main/tile_changes_per_month.html
+++ b/Website/AtariLegend/themes/templates/1/main/tile_changes_per_month.html
@@ -17,7 +17,8 @@
 *}
 <script src="{$template_dir}includes/js/vendor/Chart-2.5.0.min.js"></script> <!-- chart creation -->
 <script>
-jQuery(document).ready(function () {
+    // jQuery is not available yet at this point
+    document.addEventListener("DOMContentLoaded", function(event) {
 
     var data_cl_monthly = {$change_log_monthly_data};
     var labels_cl_monthly = {$change_log_monthly_label};

--- a/shippable.yml
+++ b/shippable.yml
@@ -14,5 +14,4 @@ build:
     # Do the actual build / CI of the project
     ci:
         - shippable_retry npm install
-        - shippable_retry pear install PHP_CodeSniffer
         - npm run grunt


### PR DESCRIPTION
I missed a few things on the games list page with scripts that were
inserted in the middle of the page and relied on jQuery to be loaded in
the `<head>`. Moved them at the bottom too.

A tricky one is the "changes per month" tile because it requires jQuery
but there's no way for a tile to inject a script at the bottom of the
page. For now I worked around it by replacing `jQuery(document).ready()`
by a native JS version (Luckily, that was the only line that used
jQuery). That will be adressed better later when we refactor scripts in
separate files.