### PR TITLE
[WIP] Create the `game_release` table

### DIFF
--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_create_release_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_create_release_table.php
@@ -1,0 +1,40 @@
+<?php
+/***************************************************************************
+ *   Initial creation of the game_release table
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 126;
+
+// Description of what the change will do.
+$update_description = "Create game_release table";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_fail";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.tables
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_release' LIMIT 1";
+
+// Database change
+$database_update_sql = "CREATE TABLE game_release (
+    `id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a release',
+    `game_id` INT NOT NULL COMMENT 'ID of the game the release is for',
+    `name` VARCHAR(255) NULL COMMENT 'Optional alternative name of the release',
+    `date` DATE NULL COMMENT 'Release date',
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (game_id) REFERENCES game(game_id)
+)
+ENGINE = InnoDB
+CHARSET = utf8
+COMMENT = 'A single release of a game'";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_populate_release_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_populate_release_table.php
@@ -1,0 +1,36 @@
+<?php
+/***************************************************************************
+ *   Populate the game_release table from the game table
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 127;
+
+// Description of what the change will do.
+$update_description = "Populate game_release table from game";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_success";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.tables
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_release' LIMIT 1";
+
+// Database change
+$database_update_sql = "INSERT INTO game_release(`game_id`, `date`)
+SELECT
+    game.game_id,
+    CONCAT(game_year.game_year, '-01-01')
+FROM
+    game
+LEFT JOIN game_year ON game_year.game_id = game.game_id";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";


### PR DESCRIPTION
Kicking off the new structure by creating the `game_release` table and
populating it:
- Create one release per game. I left the `name` column empty since it's
supposed to be for alternative names only (e.g. a translated name for
example).
- Populate the release date from the `game_year` table. Since we are
switching from a single `year` field to a full date, I've set all dates
to the 1st of January for now.

Next step is to update the frontend and CPANEL to make use of this table
whenever the game year is displayed or modified.