### PR TITLE
Alternative (hopefully simpler!) way to write changelog entries

### DIFF
--- a/Website/AtariLegend/php/admin/user/db_user_management.php
+++ b/Website/AtariLegend/php/admin/user/db_user_management.php
@@ -18,13 +18,34 @@ include("../../config/admin.php");
 include("../../vendor/phpmailer/phpmailer/PHPMailerAutoload.php");
 include("../../config/admin_rights.php");
 
+require_once __DIR__."/../../common/Model/Database/ChangeLog.php" ;
+require_once __DIR__."/../../common/DAO/ChangeLogDAO.php" ;
+
+$changeLogDao = new \AL\Common\DAO\ChangeLogDAO($mysqli);
+
 // Ajax driven delete user query
 if (isset($action) and $action == "delete_user") {
     if (isset($user_id)) {
         $start = microtime(true);
         $i     = 0;
         foreach ($user_id as $user) {
-            create_log_entry('Users', $user, 'User', $user, 'Delete', $_SESSION['user_id']);
+            $result = $mysqli->query("SELECT userid FROM users WHERE user_id=$user");
+            $row = $result->fetch_assoc();
+            $user_name = $row["userid"];
+
+            $changeLogDao->insertChangeLog(
+                new \AL\Common\Model\Database\ChangeLog(
+                    -1,
+                    "Users",
+                    $user,
+                    $user_name,
+                    "User",
+                    $user,
+                    $user_name,
+                    $_SESSION['user_id'],
+                    \AL\Common\Model\Database\ChangeLog::ACTION_DELETE
+                )
+            );
 
             $sql = $mysqli->query("DELETE FROM users WHERE user_id = '$user' ") or die("error deleting user");
             $i++;
@@ -92,7 +113,23 @@ if ((isset($action) and $action == "deactivate_user")) {
         $start = microtime(true);
         $i     = 0;
         foreach ($user_id as $user) {
-            create_log_entry('Users', $user, 'User', $user, 'Update', $_SESSION['user_id']);
+            $result = $mysqli->query("SELECT userid FROM users WHERE user_id=$user");
+            $row = $result->fetch_assoc();
+            $user_name = $row["userid"];
+
+            $changeLogDao->insertChangeLog(
+                new \AL\Common\Model\Database\ChangeLog(
+                    -1,
+                    "Users",
+                    $user,
+                    $user_name,
+                    "User",
+                    $user,
+                    $user_name,
+                    $_SESSION['user_id'],
+                    \AL\Common\Model\Database\ChangeLog::ACTION_UPDATE
+                )
+            );
 
             $sql = $mysqli->query("UPDATE users SET inactive = '1' WHERE user_id = '$user'; ") or die("error updating user");
             $i++;
@@ -109,9 +146,25 @@ if ((isset($action) and $action == "activate_user")) {
         $start = microtime(true);
         $i     = 0;
         foreach ($user_id as $user) {
-            create_log_entry('Users', $user, 'User', $user, 'Update', $_SESSION['user_id']);
+            $result = $mysqli->query("SELECT userid FROM users WHERE user_id=$user");
+            $row = $result->fetch_assoc();
+            $user_name = $row["userid"];
 
-            $sql = $mysqli->query("UPDATE users SET inactive = ' ' WHERE user_id = '$user'; ") or die("error updating user");
+            $changeLogDao->insertChangeLog(
+                new \AL\Common\Model\Database\ChangeLog(
+                    -1,
+                    "Users",
+                    $user,
+                    $user_name,
+                    "User",
+                    $user,
+                    $user_name,
+                    $_SESSION['user_id'],
+                    \AL\Common\Model\Database\ChangeLog::ACTION_UPDATE
+                )
+            );
+
+            $sql = $mysqli->query("UPDATE users SET inactive = 0 WHERE user_id = '$user'; ") or die("error updating user");
             $i++;
         }
         $time_elapsed_secs        = microtime(true) - $start;

--- a/Website/AtariLegend/php/common/DAO/ChangeLogDAO.php
+++ b/Website/AtariLegend/php/common/DAO/ChangeLogDAO.php
@@ -1,0 +1,56 @@
+<?php
+namespace AL\Common\DAO;
+
+require_once __DIR__."/../../lib/Db.php" ;
+require_once __DIR__."/../Model/Database/ChangeLog.php" ;
+
+/**
+ * DAO for DB Change Log
+ */
+class ChangeLogDAO {
+    private $mysqli;
+
+    public function __construct($mysqli) {
+        $this->mysqli = $mysqli;
+    }
+
+    /**
+     * Insert a new change log entry
+     *
+     * @param  \AL\Common\Model\Database\Changelog Change log to insert
+     * @return integer ID of the inserted change log
+     */
+    public function insertChangeLog($change_log) {
+        $stmt = \AL\Db\execute_query(
+            "ChangeLogDAO: insertChangeLog",
+            $this->mysqli,
+            "INSERT INTO change_log (
+                section,
+                section_id,
+                section_name,
+                sub_section,
+                sub_section_id,
+                sub_section_name,
+                user_id,
+                action,
+                timestamp
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "sissisisi",
+            $change_log->getSection(),
+            $change_log->getSectionId(),
+            $change_log->getSectionValue(),
+            $change_log->getSubSection(),
+            $change_log->getSubSectionId(),
+            $change_log->getSubSectionValue(),
+            $change_log->getUserId(),
+            $change_log->getAction(),
+            $change_log->getTimestamp()
+        );
+
+        $id = $stmt->insert_id;
+
+        $stmt->close();
+
+        return $id;
+    }
+}

--- a/Website/AtariLegend/php/common/Model/Database/ChangeLog.php
+++ b/Website/AtariLegend/php/common/Model/Database/ChangeLog.php
@@ -1,0 +1,137 @@
+<?php
+namespace AL\Common\Model\Database;
+
+/**
+ * Maps to the `change_log` table
+ */
+class ChangeLog {
+
+    const ACTION_UPDATE = "Update";
+    const ACTION_INSERT = "Insert";
+    const ACTION_DELETE = "Delete";
+
+    /** Permitted DB actions */
+    const ACTIONS = array(self::ACTION_UPDATE, self::ACTION_INSERT, self::ACTION_DELETE);
+
+    /** List of permitted sections and sub-sections */
+    const SECTIONS = array(
+        "Articles" => array("Article"),
+        "Author type" => array("Author type"),
+        "Bug type" => array("Bug type"),
+        "Company" => array("Company", "Logo"),
+        "Downloads" => array("Crew", "Details", "TOS"),
+        "Format" => array("Format"),
+        "Game series" => array("Game", "Series"),
+        "Games" => array("AKA", "Box back", "Box front", "Comment","Creator",
+            "Developer", "Fact", "File", "Mag score", "Music","Game", "Publisher",
+            "Review", "Review comment", "Screenshot", "Similar", "Submission", "Year"
+        ),
+        "Individuals" => array("Image", "Individual", "Nickname"),
+        "Interviews" => array("Comment", "Interview", "Screenshots"),
+        "Lingo" => array("Lingo"),
+        "Links" => array("Category", "Link", "Link submit"),
+        "Links cat" => array("Category"),
+        "Menu disk" => array("Game", "Menu disk"),
+        "Menu set" => array("Menu disk (multiple)", "Menu set", "Menu type"),
+        "Menu type" => array("Menu type"),
+        "News" => array("Image", "News item", "News submit"),
+        "Reviews" => array("Comment"),
+        "TOS" => array("TOS"),
+        "Trivia" => array("DYK", "Quote", "Spotlight"),
+        "Users" => array("Avatar", "User")
+    );
+
+    private $id;
+    private $section;
+    private $section_id;
+    private $section_value;
+    private $sub_section;
+    private $sub_section_id;
+    private $sub_section_value;
+    private $user_id;
+    private $action;
+    private $timestamp;
+
+    public function __construct(
+        $id,
+        $section,
+        $section_id,
+        $section_value,
+        $sub_section,
+        $sub_section_id,
+        $sub_section_value,
+        $user_id,
+        $action
+    ) {
+
+        $this->id = $id;
+
+        // Check if the section is valid
+        if (! array_key_exists($section, self::SECTIONS)) {
+            die("Unknown section '$section'. Only "
+                .join(", ", array_keys(self::SECTIONS))." are supported");
+        }
+        $this->section = $section;
+        $this->section_id = $section_id;
+        $this->section_value = $section_value;
+
+        // Check is the sub-section is valid for the section
+        if (! in_array($sub_section, self::SECTIONS[$section])) {
+            die("Unknown sub-section '$sub_section'. Only "
+                .join(", ", self::SECTIONS[$section])." are supported for $section");
+        }
+        $this->sub_section = $sub_section;
+        $this->sub_section_id = $sub_section_id;
+        $this->sub_section_value = $sub_section_value;
+
+        $this->user_id = $user_id;
+
+        // Check if the action is valid
+        if (! in_array($action, self::ACTIONS)) {
+            die("Unknown action '$action'. Only ".self::ACTIONS." are supported");
+        }
+        $this->action = $action;
+
+        $this->timestamp = time();
+    }
+
+    public function getId() {
+        return $this->id;
+    }
+
+    public function getSection() {
+        return $this->section;
+    }
+
+    public function getSectionId() {
+        return $this->section_id;
+    }
+
+    public function getSectionValue() {
+        return $this->section_value;
+    }
+
+    public function getSubSection() {
+        return $this->sub_section;
+    }
+
+    public function getSubSectionId() {
+        return $this->sub_section_id;
+    }
+
+    public function getSubSectionValue() {
+        return $this->sub_section_value;
+    }
+
+    public function getUserId() {
+        return $this->user_id;
+    }
+
+    public function getAction() {
+        return $this->action;
+    }
+
+    public function getTimestamp() {
+        return $this->timestamp;
+    }
+}

--- a/Website/AtariLegend/php/common/login/db_register.php
+++ b/Website/AtariLegend/php/common/login/db_register.php
@@ -19,6 +19,11 @@
 include("../../config/common.php");
 include("../../vendor/phpmailer/phpmailer/PHPMailerAutoload.php");
 
+require_once __DIR__."/../../common/Model/Database/ChangeLog.php" ;
+require_once __DIR__."/../../common/DAO/ChangeLogDAO.php" ;
+
+$changeLogDao = new \AL\Common\DAO\ChangeLogDAO($mysqli);
+
 if (isset($action) and $action == 'confirm') {
     //when the confirmation email link is pressed we enter this part of the code. We check if the user exists and set the account to active.
     //Then we auto log in!
@@ -146,7 +151,20 @@ if (isset($action) and $action == 'confirm') {
 
                             $time_elapsed_secs = microtime(true) - $start;
 
-                            create_log_entry('Users', $new_user_id, 'User', $new_user_id, 'Insert', $new_user_id);
+                            $changeLogDao->insertChangeLog(
+                                new \AL\Common\Model\Database\ChangeLog(
+                                    -1,
+                                    "Users",
+                                    $new_user_id,
+                                    $user_name,
+                                    "User",
+                                    $new_user_id,
+                                    $user_name,
+                                    null,
+                                    \AL\Common\Model\Database\ChangeLog::ACTION_INSERT
+                                )
+                            );
+
                             $_SESSION['edit_message'] = "An email was sent to you. Please follow the link to activate the account";
                             header("Location: ../../main/front/front.php");
                         }

--- a/Website/AtariLegend/php/lib/functions.php
+++ b/Website/AtariLegend/php/lib/functions.php
@@ -626,19 +626,6 @@ function create_log_entry($section, $section_id, $subsection, $subsection_id, $a
         }
     }
 
-    //  Everything we do for the USERS SECTION
-    if ($section == 'Users') {
-        // Get the username
-        $query_username = "SELECT userid FROM users WHERE user_id = '$section_id'";
-        $result = $mysqli->query($query_username) or die("getting user name failed");
-        $query_data   = $result->fetch_array(MYSQLI_BOTH);
-        $section_name = $query_data['userid'];
-
-        if ($subsection == 'Avatar' or $subsection == 'User') {
-            $subsection_name = $section_name;
-        }
-    }
-
     //  Everything we do for the LINKS section
     if ($section == 'Links') {
         // Get the website name


### PR DESCRIPTION
Added a DAO to write to the change log to avoid having to update the
very large `create_log_entry()` function whenever we want to add an
entry to the changelog.

Most of the time when calling the function to create a changelog entry
we already have the right info for the section and sub-section. Rather
than just pass an ID, and need to write some code in
`create_log_entry()` to re-query this info, just pass it directly.

That should hopefully make it a bit less error-prone to add entries to
the changelog, especially as we'll be adding more tables in the next
months.

The DAO also "validate" the changelog entry, so that you can't add a
changelog for a section or sub-section that doesn't exist. That should
help in reminding us that we also need to update the changelog frontend
whenever we add a new section or sub-section.

I only updated the code that has to do with Users changelog entries for
now, but we should start using this version for any new table if we can.