### PR TITLE
Move Atom pic inline with '?' pic

### DIFF
--- a/Sources/styles/1/scss/_general.scss
+++ b/Sources/styles/1/scss/_general.scss
@@ -700,6 +700,6 @@ div.tab button.active {
 // Feed icon (on News, Reviews, Interview)
 a.atom {
     float: left;
-    margin-top: 25px;
+    margin-top: 5px;
     margin-left: 10px;
 }


### PR DESCRIPTION
When you check the review section for example, you would notice the Atom pic was positioned lower than the '?' pic, which was not nice. I've set them to the same height.