### PR TITLE
Implement the `game_release` table

### DIFF
--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_create_release_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_create_release_table.php
@@ -1,0 +1,40 @@
+<?php
+/***************************************************************************
+ *   Initial creation of the game_release table
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 126;
+
+// Description of what the change will do.
+$update_description = "Create game_release table";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_fail";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.tables
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_release' LIMIT 1";
+
+// Database change
+$database_update_sql = "CREATE TABLE game_release (
+    `id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a release',
+    `game_id` INT NOT NULL COMMENT 'ID of the game the release is for',
+    `name` VARCHAR(255) NULL COMMENT 'Optional alternative name of the release',
+    `date` DATE NULL COMMENT 'Release date',
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (game_id) REFERENCES game(game_id)
+)
+ENGINE = InnoDB
+CHARSET = utf8
+COMMENT = 'A single release of a game'";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_populate_release_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-04_populate_release_table.php
@@ -1,0 +1,36 @@
+<?php
+/***************************************************************************
+ *   Populate the game_release table from the game table
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 127;
+
+// Description of what the change will do.
+$update_description = "Populate game_release table from game";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_success";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.tables
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_release' LIMIT 1";
+
+// Database change
+$database_update_sql = "INSERT INTO game_release(`game_id`, `date`)
+SELECT
+    game.game_id,
+    CONCAT(game_year.game_year, '-01-01')
+FROM
+    game
+LEFT JOIN game_year ON game_year.game_id = game.game_id";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-19_delete_game_year_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-19_delete_game_year_table.php
@@ -1,0 +1,30 @@
+<?php
+/***************************************************************************
+ *   Delete the game_year table (superceded by game_release)
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 128;
+
+// Description of what the change will do.
+$update_description = "Delete the game_year table";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_success";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.tables
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_year' LIMIT 1";
+
+// Database change
+$database_update_sql = "DROP TABLE game_year";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/games/ajax_game_search.php
+++ b/Website/AtariLegend/php/admin/games/ajax_game_search.php
@@ -44,7 +44,7 @@ $RESULTGAME = "SELECT game.game_id,
         pd1.pub_dev_id as 'publisher_id',
         pd2.pub_dev_name as 'developer_name',
         pd2.pub_dev_id as 'developer_id',
-        game_year.game_year
+        YEAR(game_release.date) as game_release_year
         FROM game
         LEFT JOIN game_boxscan ON (game_boxscan.game_id = game.game_id)
         LEFT JOIN screenshot_game ON (screenshot_game.game_id = game.game_id)
@@ -70,7 +70,7 @@ $RESULTGAME = "SELECT game.game_id,
       LEFT JOIN pub_dev pd1 ON (pd1.pub_dev_id = game_publisher.pub_dev_id)
       LEFT JOIN game_developer ON (game_developer.game_id = game.game_id)
       LEFT JOIN pub_dev pd2 on (pd2.pub_dev_id = game_developer.dev_pub_id)
-      LEFT JOIN game_year on (game_year.game_id = game.game_id)
+      LEFT JOIN game_release on (game_release.game_id = game.game_id)
     WHERE ";
 
 $RESULTAKA = "SELECT
@@ -90,7 +90,7 @@ $RESULTAKA = "SELECT
          pd1.pub_dev_id as 'publisher_id',
          pd2.pub_dev_name as 'developer_name',
          pd2.pub_dev_id as 'developer_id',
-         game_year.game_year
+         YEAR(game_release.date) as game_release_year
       FROM game_aka
       LEFT JOIN game ON (game_aka.game_id = game.game_id)
       LEFT JOIN game_boxscan ON (game_boxscan.game_id = game_aka.game_id)
@@ -117,7 +117,7 @@ $RESULTAKA = "SELECT
       LEFT JOIN pub_dev pd1 ON (game_publisher.pub_dev_id = pd1.pub_dev_id)
       LEFT JOIN game_developer ON (game.game_id = game_developer.game_id)
       LEFT JOIN pub_dev pd2 on (pd2.pub_dev_id = game_developer.dev_pub_id)
-      LEFT JOIN game_year on (game_year.game_id = game.game_id)
+      LEFT JOIN game_release on (game_release.game_id = game.game_id)
      WHERE ";
 
 if (empty($action)) {
@@ -171,9 +171,9 @@ if (isset($action) and $action == "search") {
     if (empty($year) or $year == '-') {
         $year_select = '';
     } elseif ($year == "no_year_set") {
-        $year_select = " AND game_year.game_year IS NULL";
+        $year_select = " AND game_release.date IS NULL";
     } else {
-        $year_select = " AND game_year.game_year LIKE '$year%'";
+        $year_select = " AND CONVERT(YEAR(game_release.date), CHAR(4)) LIKE '$year%'";
     }
 
     //
@@ -401,7 +401,7 @@ if (isset($action) and $action == "search") {
                         'publisher_name' => $pub_name,
                         'developer_id' => $sql_game_search['developer_id'],
                         'developer_name' => $dev_name,
-                        'year' => $sql_game_search['game_year'],
+                        'year' => $sql_game_search['game_release_year'],
                         'music' => $sql_game_search['music_id'],
                         'boxscan' => $sql_game_search['game_boxscan_id'],
                         'download' => $sql_game_search['game_download_id'],

--- a/Website/AtariLegend/php/admin/games/games_detail.php
+++ b/Website/AtariLegend/php/admin/games/games_detail.php
@@ -24,6 +24,10 @@ include("../../config/common.php");
 include("../../config/admin.php");
 include("../../admin/games/quick_search_games.php");
 
+require_once __DIR__."/../../common/DAO/GameReleaseDAO.php";
+
+$gameReleaseDao = new \AL\Common\DAO\GameReleaseDAO($mysqli);
+
 //***********************************************************************************
 //Let's get the general game info first.
 //***********************************************************************************
@@ -91,17 +95,7 @@ while ($game_info = $sql_game->fetch_array(MYSQLI_BOTH)) {
 //get the release dates
 //***********************************************************************************
 
-$sql_year = $mysqli->query("SELECT * FROM game_year
-               LEFT JOIN game_extra_info ON ( game_year.game_extra_info_id = game_extra_info.game_extra_info_id )
-               WHERE game_id='$game_id'") or die("Error loading year");
-
-while ($year = $sql_year->fetch_array(MYSQLI_BOTH)) {
-    $smarty->append('game_year_detail', array(
-        'game_year_id' => $year['game_year_id'],
-        'game_year' => $year['game_year'],
-        'game_extra_info' => $year['game_extra_info']
-    ));
-}
+$smarty->assign('game_releases', $gameReleaseDao->getReleasesForGame($game_id));
 
 //***********************************************************************************
 //get the game categories & the categories already selected for this game

--- a/Website/AtariLegend/php/admin/games/games_main.php
+++ b/Website/AtariLegend/php/admin/games/games_main.php
@@ -52,7 +52,7 @@ $RESULTGAME = "SELECT game.game_id,
         pd1.pub_dev_id as 'publisher_id',
         pd2.pub_dev_name as 'developer_name',
         pd2.pub_dev_id as 'developer_id',
-        game_year.game_year
+        YEAR(game_release.date) as game_release_year
         FROM game
         LEFT JOIN game_boxscan ON (game_boxscan.game_id = game.game_id)
         LEFT JOIN screenshot_game ON (screenshot_game.game_id = game.game_id)
@@ -78,7 +78,7 @@ $RESULTGAME = "SELECT game.game_id,
       LEFT JOIN pub_dev pd1 ON (pd1.pub_dev_id = game_publisher.pub_dev_id)
       LEFT JOIN game_developer ON (game_developer.game_id = game.game_id)
       LEFT JOIN pub_dev pd2 on (pd2.pub_dev_id = game_developer.dev_pub_id)
-      LEFT JOIN game_year on (game_year.game_id = game.game_id)
+      LEFT JOIN game_release on (game_release.game_id = game.game_id)
     WHERE ";
 
 $RESULTAKA = "SELECT
@@ -98,7 +98,7 @@ $RESULTAKA = "SELECT
          pd1.pub_dev_id as 'publisher_id',
          pd2.pub_dev_name as 'developer_name',
          pd2.pub_dev_id as 'developer_id',
-         game_year.game_year
+         YEAR(game_release.date) as game_release_year
       FROM game_aka
       LEFT JOIN game ON (game_aka.game_id = game.game_id)
       LEFT JOIN game_boxscan ON (game_boxscan.game_id = game_aka.game_id)
@@ -125,7 +125,7 @@ $RESULTAKA = "SELECT
       LEFT JOIN pub_dev pd1 ON (game_publisher.pub_dev_id = pd1.pub_dev_id)
       LEFT JOIN game_developer ON (game.game_id = game_developer.game_id)
       LEFT JOIN pub_dev pd2 on (pd2.pub_dev_id = game_developer.dev_pub_id)
-      LEFT JOIN game_year on (game_year.game_id = game.game_id)
+      LEFT JOIN game_release on (game_release.game_id = game.game_id)
      WHERE ";
 
      $RESULTGAME .= "game.game_name REGEXP '^[0-9].*'";
@@ -182,7 +182,7 @@ $RESULTAKA = "SELECT
              'developer_id' => $sql_game_search['developer_id'],
              'developer_name' => $dev_name,
              //'year_id' => $sql_game_search['year_id'],
-             'year' => $sql_game_search['game_year'],
+             'year' => $sql_game_search['game_release_year'],
              'music' => $sql_game_search['music_id'],
              'boxscan' => $sql_game_search['game_boxscan_id'],
              'download' => $sql_game_search['game_download_id'],

--- a/Website/AtariLegend/php/admin/games/games_review.php
+++ b/Website/AtariLegend/php/admin/games/games_review.php
@@ -35,17 +35,15 @@ $RESULTGAME = "SELECT
                     game.game_name,
                     pub_dev.pub_dev_name,
                     pub_dev.pub_dev_id,
-                    game_year.game_year,
                     users.userid,
                     review_main.review_date
                     FROM game
                     LEFT JOIN game_publisher ON ( game.game_id = game_publisher.game_id )
                     LEFT JOIN pub_dev ON ( game_publisher.pub_dev_id = pub_dev.pub_dev_id )
-                    LEFT JOIN game_year ON ( game_year.game_id = game.game_id )
                     LEFT JOIN review_game ON ( review_game.game_id = game.game_id )
                     LEFT JOIN review_main ON ( review_main.review_id = review_game.review_id)
                     LEFT JOIN users ON ( review_main.user_id = users.user_id)
-                    WHERE review_game.game_id IS NOT NULL 
+                    WHERE review_game.game_id IS NOT NULL
                     GROUP BY game.game_id, game.game_name HAVING COUNT(DISTINCT game.game_id, game.game_name) = 1
                     ORDER BY review_main.review_date DESC";
 

--- a/Website/AtariLegend/php/admin/games/games_review_list.php
+++ b/Website/AtariLegend/php/admin/games/games_review_list.php
@@ -29,13 +29,13 @@ $RESULTGAME = "SELECT
                     game.game_name,
                     pub_dev.pub_dev_name,
                     pub_dev.pub_dev_id,
-                    game_year.game_year,
+                    YEAR(game_release.date) as game_release_year,
                     users.userid,
                     review_main.review_date
                     FROM game
                     LEFT JOIN game_publisher ON ( game.game_id = game_publisher.game_id )
                     LEFT JOIN pub_dev ON ( game_publisher.pub_dev_id = pub_dev.pub_dev_id )
-                    LEFT JOIN game_year ON ( game_year.game_id = game.game_id )
+                    LEFT JOIN game_release ON ( game_release.game_id = game.game_id )
                     LEFT JOIN review_game ON ( review_game.game_id = game.game_id )
                     LEFT JOIN review_main ON ( review_main.review_id = review_game.review_id)
                     LEFT JOIN users ON ( review_main.user_id = users.user_id)
@@ -99,11 +99,11 @@ if (isset($action) and $action == 'search') {
                             game.game_name,
                             pub_dev.pub_dev_name,
                             pub_dev.pub_dev_id,
-                            game_year.game_year
+                            YEAR(game_release.date) as game_release_year
                        FROM game
                        LEFT JOIN game_publisher ON ( game.game_id = game_publisher.game_id )
                        LEFT JOIN pub_dev ON ( game_publisher.pub_dev_id = pub_dev.pub_dev_id )
-                       LEFT JOIN game_year ON ( game_year.game_id = game.game_id ) WHERE ";
+                       LEFT JOIN game_release ON ( game_release.game_id = game.game_id ) WHERE ";
 
         $RESULTGAME .= $gamebrowse_select;
         $gamesearch = $mysqli->real_escape_string($gamesearch);
@@ -132,7 +132,7 @@ if (isset($action) and $action == 'search') {
                         'game_id' => $row['game_id'],
                         'game_name' => $row['game_name'],
                         'game_publisher' => $row['pub_dev_name'],
-                        'game_year' => $row['game_year'],
+                        'game_release_year' => $row['game_release_year'],
                         'number_reviews' => $array['count']
                     ));
                 }

--- a/Website/AtariLegend/php/admin/games/games_series_add_games.php
+++ b/Website/AtariLegend/php/admin/games/games_series_add_games.php
@@ -66,9 +66,9 @@ if ($action == 'add_games_search') {
                        pd1.pub_dev_name as 'publisher_name',
                        game_developer.dev_pub_id as 'developer_id',
                        pd2.pub_dev_name as 'developer_name',
-                       game_year.game_year AS 'year'";
+                       YEAR(game_release.date) as 'year'";
         $sql_build .= " FROM game ";
-        $sql_build .= " LEFT JOIN game_year on (game_year.game_id = game.game_id) ";
+        $sql_build .= " LEFT JOIN game_release on (game_release.game_id = game.game_id) ";
         $sql_build .= " LEFT JOIN game_publisher ON (game_publisher.game_id = game.game_id)";
         $sql_build .= " LEFT JOIN pub_dev pd1 ON (pd1.pub_dev_id = game_publisher.pub_dev_id)";
         $sql_build .= " LEFT JOIN game_developer ON (game_developer.game_id = game.game_id)";
@@ -102,9 +102,9 @@ if ($action == 'add_games_search') {
                        pd1.pub_dev_name as 'publisher_name',
                        game_developer.dev_pub_id as 'developer_id',
                        pd2.pub_dev_name as 'developer_name',
-                       game_year.game_year AS 'year'";
+                       YEAR(game_release.date) as 'year'";
         $sql_build .= " FROM game ";
-        $sql_build .= " LEFT JOIN game_year on (game_year.game_id = game.game_id) ";
+        $sql_build .= " LEFT JOIN game_release on (game_release.game_id = game.game_id) ";
         $sql_build .= " LEFT JOIN game_publisher ON (game_publisher.game_id = game.game_id)";
         $sql_build .= " LEFT JOIN pub_dev pd1 ON (pd1.pub_dev_id = game_publisher.pub_dev_id)";
         $sql_build .= " LEFT JOIN game_developer ON (game_developer.game_id = game.game_id)";
@@ -142,9 +142,9 @@ if ($action == 'add_games_search') {
                    pd1.pub_dev_name as 'publisher_name',
                    game_developer.dev_pub_id as 'developer_id',
                    pd2.pub_dev_name as 'developer_name',
-                   game_year.game_year AS 'year'";
+                   YEAR(game_release.date) as 'year'";
     $sql_build .= " FROM game ";
-    $sql_build .= " LEFT JOIN game_year on (game_year.game_id = game.game_id) ";
+    $sql_build .= " LEFT JOIN game_release on (game_release.game_id = game.game_id) ";
     $sql_build .= " LEFT JOIN game_publisher ON (game_publisher.game_id = game.game_id)";
     $sql_build .= " LEFT JOIN pub_dev pd1 ON (pd1.pub_dev_id = game_publisher.pub_dev_id)";
     $sql_build .= " LEFT JOIN game_developer ON (game_developer.game_id = game.game_id)";

--- a/Website/AtariLegend/php/admin/games/games_series_editor.php
+++ b/Website/AtariLegend/php/admin/games/games_series_editor.php
@@ -49,7 +49,7 @@ $sql_series_link = $mysqli->query("SELECT game.game_id,
                game_developer.dev_pub_id as 'developer_id',
                pd2.pub_dev_name as 'developer_name',
                game_series_cross.game_series_cross_id,
-               game_year.game_year
+               YEAR(game_release.date) as game_release_year
                 FROM game_series_cross
                 LEFT JOIN game ON (game_series_cross.game_id = game.game_id)
                 LEFT JOIN game_series ON (game_series_cross.game_series_id = game_series.game_series_id)
@@ -57,7 +57,7 @@ $sql_series_link = $mysqli->query("SELECT game.game_id,
                 LEFT JOIN pub_dev pd1 ON (pd1.pub_dev_id = game_publisher.pub_dev_id)
                 LEFT JOIN game_developer ON (game_developer.game_id = game.game_id)
                 LEFT JOIN pub_dev pd2 on (pd2.pub_dev_id = game_developer.dev_pub_id)
-                LEFT JOIN game_year ON (game.game_id = game_year.game_id)
+                LEFT JOIN game_release ON (game.game_id = game_release.game_id)
                 WHERE game_series_cross.game_series_id='$game_series_id' GROUP BY game.game_name ORDER BY game.game_name") or die("Couldn't query Game Series Database3.1");
 // check how many games is linked to a particular series
 $sql_series_link_nr = $sql_series_link->num_rows;
@@ -78,7 +78,7 @@ while ($query_series_link = $sql_series_link->fetch_array(MYSQLI_BOTH)) { // Thi
         'developer_name' => $query_series_link['developer_name'],
         'developer_id' => $query_series_link['developer_id'],
         'game_series_cross_id' => $query_series_link['game_series_cross_id'],
-        'year' => $query_series_link['game_year']
+        'year' => $query_series_link['game_release_year']
     ));
 }
 

--- a/Website/AtariLegend/php/admin/games/quick_search_games.php
+++ b/Website/AtariLegend/php/admin/games/quick_search_games.php
@@ -10,6 +10,10 @@
 *
 ***************************************************************************/
 
+require_once __DIR__."/../../common/DAO/GameReleaseDAO.php";
+
+$gameReleaseDao = new \AL\Common\DAO\GameReleaseDAO($mysqli);
+
 /*
 ***********************************************************************************
 This is the include to fill the quick search games side menu
@@ -47,13 +51,8 @@ while ($company_developer = $sql_developer->fetch_array(MYSQLI_BOTH)) {
 }
 
 //Get Year values to fill the searchfield
-$sql_year = $mysqli->query("SELECT distinct game_year from game_year order by game_year")
-                     or die("problems getting data from game_year table");
-
-while ($game_year = $sql_year->fetch_array(MYSQLI_BOTH)) {
-    $smarty->append('game_year', array(
-            'game_year' => $game_year['game_year']));
-}
+$years = $gameReleaseDao->getAllReleasesYears();
+$smarty->assign("game_release_years", $years);
 
 // Create dropdown values a-z
 $az_value = az_dropdown_value(0);

--- a/Website/AtariLegend/php/common/DAO/GameReleaseDAO.php
+++ b/Website/AtariLegend/php/common/DAO/GameReleaseDAO.php
@@ -1,0 +1,149 @@
+<?php
+namespace AL\Common\DAO;
+
+require_once __DIR__."/../../lib/Db.php" ;
+require_once __DIR__."/../Model/Game/GameRelease.php" ;
+
+/**
+ * DAO for Game Releases
+ */
+class GameReleaseDAO {
+    private $mysqli;
+
+    public function __construct($mysqli) {
+        $this->mysqli = $mysqli;
+    }
+
+    /**
+     * Insert a release for a game
+     *
+     * @param  integer $game_id Id of the game the release is for
+     * @param  string $name Alternative name for the release (optional)
+     * @param  date $date Date of the release (optional)
+     * @return integer ID of the inserted release
+     */
+    public function addReleaseForGame($game_id, $name = null, $date = null) {
+        $stmt = \AL\Db\execute_query(
+            "GameReleaseDAO: addReleaseForGame",
+            $this->mysqli,
+            "INSERT INTO game_release (game_id, `name`, `date`) VALUES (?, ?, ?)",
+            "iss", $game_id, $name, $date." 00:00:00"
+        );
+
+        $id = $stmt->insert_id;
+
+        $stmt->close();
+
+        return $id;
+    }
+
+    /**
+     * Get all the releases for a game
+     * @param integer $game_id ID of the game to get releases for
+     * @return \AL\Common\Model\Game\GameRelease[] An array of releases
+     */
+    public function getReleasesForGame($game_id) {
+        $stmt = \AL\Db\execute_query(
+            "GameRelaseDAO: getReleasesForGame",
+            $this->mysqli,
+            "SELECT id, `name`, `date` FROM game_release WHERE game_id = ?",
+            "i", $game_id
+        );
+
+        \AL\Db\bind_result(
+            "GameRelaseDAO: getReleasesForGame",
+            $stmt,
+            $id, $name, $date
+        );
+
+        $releases = [];
+        while ($stmt->fetch()) {
+            $releases[] = new \AL\Common\Model\Game\GameRelease(
+                $id, $game_id, $name, $date
+            );
+        }
+
+        $stmt->close();
+
+        return $releases;
+    }
+
+    /**
+     * Get a single release from its ID
+     *
+     * @param integer $release_id ID of the release to get
+     * @return \AL\Common\Model\Game\GameRelease a release, or null if not found
+     */
+    public function getRelease($release_id) {
+        $stmt = \AL\Db\execute_query(
+            "GameReleaseDAO: getRelease: $release_id",
+            $this->mysqli,
+            "SELECT id, game_id, `name`, `date` FROM game_release WHERE id = ?",
+            "i", $release_id
+        );
+
+        \AL\Db\bind_result(
+            "GameReleaseDAO: getRelease: $release_id",
+            $stmt,
+            $id, $game_id, $name, $date
+        );
+
+        $release = null;
+        if ($stmt->fetch()) {
+            $release = new \AL\Common\Model\Game\GameRelease(
+                $id, $game_id, $name, $date
+            );
+        }
+
+        $stmt->close();
+
+        return $release;
+    }
+
+    /**
+     * Delete a release
+     *
+     * @param integer $release_id ID of the release to delete
+     */
+    public function deleteRelease($release_id) {
+        $stmt = \AL\Db\execute_query(
+            "GameRelaseDAO: deleteRelease",
+            $this->mysqli,
+            "DELETE FROM game_release WHERE id = ?",
+            "i", $release_id
+        );
+
+        $stmt->close();
+    }
+
+    /**
+     * Get all the distinct release years we have in the DB
+     *
+     * @return integer[] List of years
+     */
+    public function getAllReleasesYears() {
+        $stmt = \AL\Db\execute_query(
+            "GameReleaseDAO: getAllReleasesYears",
+            $this->mysqli,
+            "SELECT DISTINCT YEAR(`date`) FROM game_release
+            WHERE `date` IS NOT NULL
+            ORDER by `date` ASC",
+            null, null
+        );
+
+        \AL\Db\bind_result(
+            "GameRelaseDAO: getAllReleases",
+            $stmt,
+            $year
+        );
+
+        $years = [];
+        while ($stmt->fetch()) {
+            $years[] = $year;
+        }
+
+        $stmt->close();
+
+        return $years;
+    }
+}

--- a/Website/AtariLegend/php/common/Model/Database/ChangeLog.php
+++ b/Website/AtariLegend/php/common/Model/Database/ChangeLog.php
@@ -24,7 +24,8 @@ class ChangeLog {
         "Game series" => array("Game", "Series"),
         "Games" => array("AKA", "Box back", "Box front", "Comment","Creator",
             "Developer", "Fact", "File", "Mag score", "Music","Game", "Publisher",
-            "Review", "Review comment", "Screenshot", "Similar", "Submission", "Year"
+            "Review", "Review comment", "Screenshot", "Similar", "Submission", "Year",
+            "Release"
         ),
         "Individuals" => array("Image", "Individual", "Nickname"),
         "Interviews" => array("Comment", "Interview", "Screenshots"),

--- a/Website/AtariLegend/php/common/Model/Game/GameRelease.php
+++ b/Website/AtariLegend/php/common/Model/Game/GameRelease.php
@@ -1,0 +1,31 @@
+<?php
+namespace AL\Common\Model\Game;
+
+/**
+ * Maps to the `game_rlease` table
+ */
+class GameRelease {
+    private $id;
+    private $game_id;
+    private $name;
+    private $date;
+
+    public function __construct($id, $game_id, $name, $date) {
+        $this->id = $id;
+        $this->game_id = $game_id;
+        $this->name = $name;
+        $this->date = $date;
+    }
+
+    public function getId() {
+        return $this->id;
+    }
+
+    public function getDate() {
+        return $this->date;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+}

--- a/Website/AtariLegend/php/common/tiles/screenstar.php
+++ b/Website/AtariLegend/php/common/tiles/screenstar.php
@@ -25,7 +25,7 @@ $query_screenstar = $mysqli->query("SELECT
                     users.user_id,
                     users.userid,
                     pub_dev.pub_dev_name,
-                    game_year.game_year,
+                    YEAR(game_release.date) as game_release_year,
 					screenshot_main.screenshot_id,
 					screenshot_main.imgext
 					FROM review_game
@@ -36,7 +36,7 @@ $query_screenstar = $mysqli->query("SELECT
 					LEFT JOIN screenshot_main ON (screenshot_game.screenshot_id = screenshot_main.screenshot_id)
                     LEFT JOIN game_developer ON (game_developer.game_id = game.game_id)
                     LEFT JOIN pub_dev ON (pub_dev.pub_dev_id = game_developer.dev_pub_id)
-                    LEFT JOIN game_year ON (game_year.game_id = game.game_id)
+                    LEFT JOIN game_release ON (game_release.game_id = game.game_id)
 					WHERE CHAR_LENGTH( game_name ) <15 ORDER BY RAND() LIMIT 1") or die("query error, screenstar");
 
 $sql_screenstar = $query_screenstar->fetch_array(MYSQLI_BOTH);
@@ -76,6 +76,6 @@ $sql_screenstar = $query_screenstar->fetch_array(MYSQLI_BOTH);
            'screenstar_game_id' => $sql_screenstar['game_id'],
            'screenstar_date'  => date("d/m/Y", $sql_screenstar['review_date']),
            'screenstar_developer' => $sql_screenstar['pub_dev_name'],
-           'screenstar_year' => $sql_screenstar['game_year'],
+           'screenstar_year' => $sql_screenstar['game_release_year'],
            'screenstar_img' => $screenstar_image)
     );

--- a/Website/AtariLegend/php/includes/autocomplete.php
+++ b/Website/AtariLegend/php/includes/autocomplete.php
@@ -17,6 +17,10 @@
  *********************************************************************************/
 
 include("../config/connect.php");
+require_once __DIR__."/../common/DAO/GameReleaseDAO.php";
+
+$gameReleaseDao = new \AL\Common\DAO\GameReleaseDAO($mysqli);
+
 $text = $mysqli->real_escape_string($_GET['term']);
 
 $json = array();
@@ -79,13 +83,11 @@ if ($extraVar == 'developer') {
 }
 
 if ($extraVar == 'year') {
-    //Get the results
-    $result = $mysqli->query("SELECT distinct game_year from game_year WHERE game_year LIKE '%$upperString%'
-                                                                       ORDER BY game_year ASC LIMIT 10")
-                     or die("problems getting data from game_year table");
-
-    while ($row = $result->fetch_assoc()) {
-        $json[] = $row['game_year'];
+    $years = $gameReleaseDao->getAllReleasesYears();
+    foreach ($years as $year) {
+        if (strpos("$year", $upperString) === 0) {
+            $json[] = "$year";
+        }
     }
 }
 

--- a/Website/AtariLegend/php/lib/Db.php
+++ b/Website/AtariLegend/php/lib/Db.php
@@ -39,7 +39,8 @@ function execute_query($context, $mysqli, $query, $bind_string, ...$params) {
         die("Error: The query [$query] contained parameters (?) but didn't have a bind string $err_ctx");
     }
 
-    $stmt->execute();
+    $stmt->execute()
+        or die("Error executing statement for [$query] $err_ctx: ".$mysqli->error);
 
     return $stmt;
 }

--- a/Website/AtariLegend/php/lib/functions.php
+++ b/Website/AtariLegend/php/lib/functions.php
@@ -333,6 +333,15 @@ function statistics_stack() {
 
     mysqli_free_result($query);
 
+    // START - RELEASE STATS
+    $query     = $mysqli->query("SELECT COUNT(id) AS count FROM game_release");
+    $game_releases = $query->fetch_array(MYSQLI_BOTH);
+    $stack[]   = "$game_releases[count] releases in archive";
+
+    // END - RELEASE STATS
+
+    mysqli_free_result($query);
+
     // START - COUNT GAME SCREENSHOTS IN ARCHIVE
     $query           = $mysqli->query("SELECT COUNT(*) AS count FROM screenshot_game");
     $gamescreencount = $query->fetch_array(MYSQLI_BOTH);
@@ -411,15 +420,6 @@ function statistics_stack() {
     $stack[]       = "$game_download[count] games have download";
 
     // END - COUNT HOW MANY GAMES HAS DOWNLOAD
-
-    mysqli_free_result($query);
-
-    // START - RELEASE YEAR STATS
-    $query     = $mysqli->query("SELECT COUNT(game_id) AS count FROM game_year");
-    $game_year = $query->fetch_array(MYSQLI_BOTH);
-    $stack[]   = "$game_year[count] games have a release year set";
-
-    // END - RELEASE YEAR STATS
 
     mysqli_free_result($query);
 
@@ -546,12 +546,7 @@ function create_log_entry($section, $section_id, $subsection, $subsection_id, $a
         }
 
         if ($subsection == 'Year') {
-            //  get the game year
-            $query_gameyear = "SELECT game_year FROM game_year WHERE game_year_id = '$subsection_id'";
-            $result = $mysqli->query($query_gameyear) or die("getting gameyear failed");
-            $query_data      = $result->fetch_array(MYSQLI_BOTH);
-            $subsection_name = $query_data['game_year'];
-            $subsection_id   = $section_id;
+            die("The table game_year has been deprecated and should not be used anymore");
         }
 
         if ($subsection == 'Similar') {

--- a/Website/AtariLegend/php/main/games/games_main.php
+++ b/Website/AtariLegend/php/main/games/games_main.php
@@ -29,19 +29,17 @@ include("../../common/tiles/screenstar.php");
 include("../../common/tiles/latest_comments_tile.php");
 include("../../common/tiles/changes_per_month_tile.php");
 
+require_once __DIR__."/../../common/DAO/GameReleaseDAO.php";
+
+$gameReleaseDao = new \AL\Common\DAO\GameReleaseDAO($mysqli);
+
 //no special position necesarry for the tiles (compared to the front page)
 //but I just declare the smarty var to avoid error
 $smarty->assign('who_is_it_tile', '');
 $smarty->assign('statistics_tile', '');
 
-// get the game_years from the game_year table
-$sql_year = $mysqli->query("SELECT distinct game_year from game_year order by game_year")
-                     or die("problems getting data from game_year table");
-
-while ($game_year = $sql_year->fetch_array(MYSQLI_BOTH)) {
-    $smarty->append('game_year', array(
-            'game_year' => $game_year['game_year']));
-}
+// Get all releases years
+$smarty->assign('releases_year', $gameReleaseDao->getAllReleasesYears());
 
 // get the categories for the genre dropdown
 $sql_cat = $mysqli->query("SELECT * from game_cat order by game_cat_name")

--- a/Website/AtariLegend/php/main/games/games_reviews_add.php
+++ b/Website/AtariLegend/php/main/games/games_reviews_add.php
@@ -88,15 +88,10 @@ if (isset($_SESSION['user_id'])) {
     while ($query_reviews_author = $sql_reviews_author->fetch_array(MYSQLI_BOTH)) {
         $count++;
 
-        //select the game year
-        $sql_game_year = $mysqli->query("SELECT * FROM game_year where game_id = $query_reviews_author[game_id]") or die("error in game year query");
-        $query_game_year = $sql_game_year->fetch_array(MYSQLI_BOTH);
-
         $smarty->append('reviews_author', array(
                 'review_id' => $query_reviews_author['review_id'],
                 'game_name' => $query_reviews_author['game_name'],
                 'game_id' => $query_reviews_author['game_id'],
-                'game_year' => $query_game_year['game_year'],
                 'user_name' => $query_reviews_author['userid'],
                 'user_id' => $query_reviews_author['user_id']
             ));

--- a/Website/AtariLegend/php/main/games/games_reviews_detail.php
+++ b/Website/AtariLegend/php/main/games/games_reviews_detail.php
@@ -94,15 +94,10 @@ $count = 0;
 while ($query_reviews_author = $sql_reviews_author->fetch_array(MYSQLI_BOTH)) {
     $count++;
 
-    //select the game year
-    $sql_game_year = $mysqli->query("SELECT * FROM game_year where game_id = $query_reviews_author[game_id]") or die("error in game year query");
-    $query_game_year = $sql_game_year->fetch_array(MYSQLI_BOTH);
-
     $smarty->append('reviews_author', array(
             'review_id' => $query_reviews_author['review_id'],
             'game_name' => $query_reviews_author['game_name'],
             'game_id' => $query_reviews_author['game_id'],
-            'game_year' => $query_game_year['game_year'],
             'user_name' => $query_reviews_author['userid'],
             'user_id' => $query_reviews_author['user_id']
         ));

--- a/Website/AtariLegend/php/main/interviews/interviews_detail.php
+++ b/Website/AtariLegend/php/main/interviews/interviews_detail.php
@@ -19,6 +19,10 @@ include("../../config/common.php");
 //load the tiles
 include("../../common/tiles/latest_interviews_tile.php");
 
+require_once __DIR__."/../../common/DAO/GameReleaseDAO.php";
+
+$gameReleaseDao = new \AL\Common\DAO\GameReleaseDAO($mysqli);
+
 //***********************************************************************************
 //Let's get all the interview and author data
 //***********************************************************************************
@@ -127,15 +131,12 @@ $count = 0;
 while ($query_games = $sql_games->fetch_array(MYSQLI_BOTH)) {
     $count++;
 
-    //select the game year
-    $sql_game_year = $mysqli->query("SELECT * FROM game_year where game_id = $query_games[game_id]")
-    or die("error in game year query");
-    $query_game_year = $sql_game_year->fetch_array(MYSQLI_BOTH);
+    $releases = $gameReleaseDao->getReleasesForGame($query_games['game_id']);
 
     $smarty->append('games', array(
         'game_id' => $query_games['game_id'],
         'game_name' => $query_games['game_name'],
-        'game_year' => $query_game_year['game_year'],
+        'game_releases' => $releases,
         'auhthor_type_info' => $query_games['author_type_info'],
         'count' => $count
     ));

--- a/Website/AtariLegend/themes/templates/1/admin/games_detail.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_detail.html
@@ -85,17 +85,20 @@ function add_creator() {
     document.getElementById('creator').submit();
 }
 
-function delete_year() {
+function delete_release()
+{
     document.getElementById('year').method="post";
-    document.getElementById('year').action="../games/db_games_detail.php?action=delete_year";
+    document.getElementById('year').action="../games/db_games_detail.php?action=delete_release";
     document.getElementById('year').submit();
 }
 
-function add_year() {
+function add_release()
+{
     document.getElementById('year').method="post";
-    document.getElementById('year').action="../games/db_games_detail.php?action=add_year";
+    document.getElementById('year').action="../games/db_games_detail.php?action=add_release";
     document.getElementById('year').submit();
 }
+
 
 function browseCompany(str) {
     if (str == "") {
@@ -425,38 +428,30 @@ function browseDeveloper(str) {
                     <div id="gd_release_year">
                         <form action="../games/db_games_detail.php" method="post" name="year" id="year">
                             <fieldset class="secondary_fieldset">
-                                <legend class="primary_legend">Release Year</legend>
-                                    {if isset($game_year_detail)}
-                                        {foreach from=$game_year_detail item=line}
-                                            <div class="links_mod_checkbox">
-                                                <input type="checkbox" id="{$line.game_year_id}" name="game_year_id[]" value="{$line.game_year_id}">
-                                                <label for="{$line.game_year_id}"></label>&nbsp;{$line.game_year} {if  isset($line.game_extra_info)}<b>({$line.game_extra_info})</b>{/if}
-                                            </div>
-                                            <br>
-                                        {/foreach}
-                                        <img src="../../../themes/templates/1/includes/img/arrow_ltr.gif" alt="" width="38" height="22" style="display:inline;">
-                                        <input type="button" name="valider" value="Delete" onclick="delete_year()" class="secondary_button" style="display:inline;">
+                                <legend class="primary_legend">Releases</legend>
+                                    {foreach from=$game_releases item=release}
+                                        <div class="links_mod_checkbox">
+                                            <input type="checkbox" id="release-{$release->getId()}" name="game_release_id[]" value="{$release->getId()}">
+                                            <label for="release-{$release->getId()}"></label>&nbsp;{$release->getDate()|date_format:"%Y"} {if $release->getName() != null}<b>({$release->getName()})</b>{/if}
+                                        </div>
                                         <br>
                                         <br>
-                                    {/if}
-                                    {html_select_date start_year=1984 display_days=0 display_months=0 class="standard_select"}
+                                    {/foreach}
+                                    <img src="../../../themes/templates/1/includes/img/arrow_ltr.gif" alt="" width="38" height="22" style="display:inline;">
+                                    <input type="button" name="valider" value="Delete" onclick="delete_release()" class="secondary_button" style="display:inline;">
+                                    <br/><br/>
+                                    {html_select_date start_year=1984 display_days=0 display_months=0 class="standard_select select_small"}
                                     <b>Release Year</b>
                                     <br>
-                                    <select name="game_extra_info_year" class="standard_select select_medium">
-                                        <option value="-" selected="selected">-</option>
-                                        {if isset($game_extra_info)}
-                                        {foreach from=$game_extra_info item=line}
-                                            <option value="{$line.game_extra_info_id}">{$line.game_extra_info}</option>
-                                        {/foreach}
-                                        {/if}
-                                    </select>
-                                    <b>Extra Info</b>
+                                    <input type="text" placeholder="Alt. title (optional)" name="release_name" class="standard_input">
                                     <br><br>
                                     <input type="hidden" name="game_id" value="{$game_id}">
-                                    <input type="button" value="Add" onclick="add_year()" class="secondary_button">
+                                    <input type="button" value="Add" onclick="add_release()" class="secondary_button">
                             </fieldset>
                         </form>
                         <br>
+                    </div>
+                    <div>
                     </div>
                 </div>
                 <div id="gd_center">

--- a/Website/AtariLegend/themes/templates/1/admin/games_review_list.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_review_list.html
@@ -43,7 +43,7 @@ The main game page
                     <tr>
                         <td>{if $line.game_name != ''}<a href="games_review_add.php?game_id={$line.game_id}" class="standard_tile_text_center">{$line.game_name}</a>{else}<i>n/a</i>{/if}</td>
                         <td>{if $line.game_publisher != ''}{$line.game_publisher}{else}<i>n/a</i>{/if}</td>
-                        <td>{if $line.game_year != ''}{$line.game_year}{else}<i>n/a</i>{/if}</td>
+                        <td>{if $line.game_release_year != ''}{$line.game_release_year}{else}<i>n/a</i>{/if}</td>
                         <td>{if $line.number_reviews != ''}{$line.number_reviews}{else}<i>0</i>{/if}</td>
                     </tr>
                 {/foreach}

--- a/Website/AtariLegend/themes/templates/1/admin/quick_search_games.html
+++ b/Website/AtariLegend/themes/templates/1/admin/quick_search_games.html
@@ -71,8 +71,8 @@
                         <select name="year" id="JSCpanelYearBrowse" class="standard_select select_large">
                             <option value="-" SELECTED>-</option>
                             <option value="no_year_set">No Release Year Set</option>
-                            {foreach from=$game_year item=line}
-                                <option value="{$line.game_year}">{$line.game_year}</option>
+                            {foreach from=$game_release_years item=year}
+                                <option value="{$year}">{$year}</option>
                             {/foreach}
                         </select>
                     </div>

--- a/Website/AtariLegend/themes/templates/1/main/games_detail_info.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_detail_info.html
@@ -125,32 +125,28 @@
                     {/if}
                 {/foreach}
             {/if}
-            {if isset($game_year)}
-                {foreach from=$game_year item=line name=game_year}
-                    <tr>
-                        <td class="w-30">
-                        {if $smarty.foreach.game_year.index == 0}
-                            <span class="games_main_detail_info_right">Year</span>
+            {if isset($releases)}
+                {foreach from=$releases item=$release name=release}
+                <tr>
+                    <td class="w-30">
+                        {if $smarty.foreach.release.index == 0}
+                            <span class="games_main_detail_info_right">Releases</span>
                         {/if}
-                            {if $line.extra_info != ''}
-                                <br><br>
+                    </td>
+                    <td class="w-5">
+                        <span class="games_main_detail_info_left text-center">-</span>
+                    </td>
+                    <td class="w-60">
+                        <span class="games_main_detail_info_left">
+                            <a href="games_main_list.php?year={$release->getDate()|date_format:"%Y"}&amp;action=search" class="standard_tile_link">
+                                {$release->getDate()|date_format:"%Y"}
+                            </a>
+                            {if $release->getName()}
+                                <small class="standard_tile_subtext">as "<em>{$release->getName()}</em>"</small>
                             {/if}
-                        </td>
-                        <td class="w-5">
-                            <span class="games_main_detail_info_left text-center">-</span>
-                            {if $line.extra_info != ''}
-                                <br><br>
-                            {/if}
-                        </td>
-                        <td class="w-60">
-                            <span class="games_main_detail_info_left">
-                                <a href="games_main_list.php?year={$line.game_year}&amp;action=search" class="standard_tile_link">{$line.game_year}</a>
-                            </span>
-                            {if $line.extra_info != ''}
-                                <br><span class="standard_tile_subtext">{$line.extra_info}</span>
-                            {/if}
-                        </td>
-                    </tr>
+                        </span>
+                    </td>
+                </tr>
                 {/foreach}
             {/if}
             {if isset($developer)}

--- a/Website/AtariLegend/themes/templates/1/main/games_detail_similar.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_detail_similar.html
@@ -30,9 +30,6 @@
                                 <a href="games_main_list.php?developer={$similar.game_dev_id}&amp;action=search">{$similar.game_dev_name}</a>
                             </span><span class="tile_arrow"><i class="fa fa-chevron-up" aria-hidden="true"></i></span>
                             <span class="tile_title"><a href="../games/games_detail.php?game_id={$similar.game_id}">{$similar.game_name}</a></span>
-                            <p class="icon-links" style="width:85%;">
-                                <span class="standard_tile_subtext" style="font-size:7pt;"><a href="../games/games_main_list.php?year={$similar.game_year}&action=search">{$similar.game_year}</a></span>
-                            </p>
                         </figcaption>
                     </figure>
                 </div>

--- a/Website/AtariLegend/themes/templates/1/main/games_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_main.html
@@ -281,8 +281,8 @@ The main game page
                         <div class="games_main_input_site">
                             <select name="year" id="games_main_year_drop" style="display:none;" class="standard_select">
                                 <option value="-" SELECTED>-</option>
-                                {foreach from=$game_year item=line}
-                                    <option value="{$line.game_year}">{$line.game_year}</option>
+                                {foreach from=$releases_year item=year}
+                                    <option value="{$year}">{$year}</option>
                                 {/foreach}
                             </select>
                             <input type="text" name="year_input" value="" class="standard_input input_full autocompleted" id="games_main_year_input" data-autocomplete-param="year">

--- a/Website/AtariLegend/themes/templates/1/main/games_main_list.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_main_list.html
@@ -283,8 +283,8 @@ The main game page
                             <div class="games_main_input_site">
                                 <select name="year" id="games_main_year_drop" style="display:none;" class="standard_select">
                                     <option value="-" SELECTED>-</option>
-                                    {foreach from=$game_year item=line}
-                                        <option value="{$line.game_year}">{$line.game_year}</option>
+                                    {foreach from=$releases_year item=year}
+                                        <option value="{$year}">{$year}</option>
                                     {/foreach}
                                 </select>
                                 <input type="text" name="year_input" value="" class="standard_input input_full autocompleted" id="games_main_year_input" data-autocomplete-param="year">

--- a/Website/AtariLegend/themes/templates/1/main/games_reviews_add.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_reviews_add.html
@@ -356,14 +356,9 @@
                         </tr>
                         {foreach from=$reviews_author item=line name=reviews_author}
                             <tr>
-                                <td class="w-90">
+                                <td>
                                     <span style="overflow: hidden;text-overflow: ellipsis"><a href="../games/games_detail.php?game_id={$line.game_id}" class="standard_tile_link" style="margin-left:10px;">{$line.game_name}</a></span>
                                     <br><span class="standard_tile_subtext" style="margin-left:15px;"><a href="../games/games_reviews_detail.php?review_id={$line.review_id}&game_id={$line.game_id}" style="margin-left:10px;">read more</a></span>
-                                </td>
-
-                                <td class="w-10">
-                                    <a href="../games/games_main_list.php?year={$line.game_year}&amp;action=search" class="standard_tile_link" style="margin-right:10px;">{$line.game_year}</a>
-                                    <br><br>
                                 </td>
                             </tr>
                         {/foreach}

--- a/Website/AtariLegend/themes/templates/1/main/games_reviews_detail.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_reviews_detail.html
@@ -374,14 +374,9 @@
                         </tr>
                         {foreach from=$reviews_author item=line name=reviews_author}
                             <tr>
-                                <td class="w-90">
+                                <td>
                                     <span style="overflow: hidden;text-overflow: ellipsis"><a href="../games/games_detail.php?game_id={$line.game_id}" class="standard_tile_link" style="margin-left:10px;">{$line.game_name}</a></span>
                                     <br><span class="standard_tile_subtext" style="margin-left:15px;"><a href="../games/games_reviews_detail.php?review_id={$line.review_id}&game_id={$line.game_id}" style="margin-left:10px;">read more</a></span>
-                                </td>
-
-                                <td class="w-10">
-                                    <a href="../games/games_main_list.php?year={$line.game_year}&amp;action=search" class="standard_tile_link" style="margin-right:10px;">{$line.game_year}</a>
-                                    <br><br>
                                 </td>
                             </tr>
                         {/foreach}

--- a/Website/AtariLegend/themes/templates/1/main/interviews_detail.html
+++ b/Website/AtariLegend/themes/templates/1/main/interviews_detail.html
@@ -441,7 +441,9 @@
                                 </td>
 
                                 <td style="width:10%;">
-                                    <a href="../games/games_main_list.php?year={$line.game_year}&amp;action=search" class="standard_tile_link" style="margin-right:10px;">{$line.game_year}</a>
+                                    {foreach from=$line.game_releases item=$release}
+                                        <a href="../games/games_main_list.php?year={$release->getDate()|date_format:"%Y"}&amp;action=search" class="standard_tile_link" style="margin-right:10px;">{$release->getDate()|date_format:"%Y"}</a>
+                                    {/foreach}
                                     <br><br>
                                 </td>
                             </tr>


### PR DESCRIPTION
Kicking off the new structure by creating the `game_release` table and
populating it:
- Create one release per `game_year`. I left the `name` column empty
since it's supposed to be for alternative names only (e.g. a translated
name for example).
- Populate the release date from the `game_year` table. Since we are
switching from a single `year` field to a full date, I've set all dates
to the 1st of January for now.
- Delete the `game_year` table.

Then, updated the frontend and cpanel to make use of the `game_release`
table whenever `game_year` was used.

In a lot of cases the code was making the assumption that there was only
one `game_year` for each game, and was picking the first year: On every
table (Like the list of games, reviews, interviews), the screenstar
panel, etc.

I was unsure what to do about this, as in a lot of cases the multiple
**releases** should be listed, than just multiple dates. But it's a bit
too early to do that. So in some cases I left it as-is, in other cases I
just removed the year from the list. I think we'll need to get back to
that once the releases are a bit more fleshed out.

I updated the cpanel game editor to replace the "Release year" section
with a "Release" one, where a year can be chosen + an alternative title
for the release (which goes into `game_release.name`).

I left some sections like menus and downloads untouched, since we want
to change the DB structure for these too there was no point in fixing
them right now.