### PR TITLE
Fixes #468: Ensure new users are recorded in the changelog

### DIFF
--- a/Website/AtariLegend/php/common/login/db_register.php
+++ b/Website/AtariLegend/php/common/login/db_register.php
@@ -160,7 +160,7 @@ if (isset($action) and $action == 'confirm') {
                                     "User",
                                     $new_user_id,
                                     $user_name,
-                                    null,
+                                    $new_user_id,
                                     \AL\Common\Model\Database\ChangeLog::ACTION_INSERT
                                 )
                             );


### PR DESCRIPTION
The `$user_id` column value was missing (the ID of the user that made
the change).