### PR TITLE
Attempt to fix Shippable

### DIFF
--- a/Docker/php/Dockerfile
+++ b/Docker/php/Dockerfile
@@ -1,6 +1,7 @@
 FROM php:5.6-apache
 
 RUN apt-get update -y
+RUN apt-get install -y gnupg
 RUN apt-get install -y libpng-dev
 RUN apt-get install -y libjpeg62-turbo-dev
 


### PR DESCRIPTION
Add package that seems to be missing on the Docker image