### PR TITLE
Minor fixes to table comments

### DIFF
--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_enhancement_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_enhancement_table.php
@@ -29,7 +29,7 @@ $database_update_sql = "CREATE TABLE game_release_system_enhanced (
 )
 ENGINE = InnoDB
 CHARSET = utf8
-COMMENT = 'Table used for setting enhancements'";
+COMMENT = 'List systems for which a release has been enhanced'";
 
 // If the update should auto execute without user interaction set to "yes".
 $database_autoexecute = "yes";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_incompability_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_incompability_table.php
@@ -29,7 +29,7 @@ $database_update_sql = "CREATE TABLE game_release_system_incompatible (
 )
 ENGINE = InnoDB
 CHARSET = utf8
-COMMENT = 'Table used for setting compatability'";
+COMMENT = 'List systems a release is not compatible with'";
 
 // If the update should auto execute without user interaction set to "yes".
 $database_autoexecute = "yes";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_system_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_system_table.php
@@ -26,7 +26,7 @@ $database_update_sql = "CREATE TABLE system (
 )
 ENGINE = InnoDB
 CHARSET = utf8
-COMMENT = 'System table used for setting enhancements or compability'";
+COMMENT = 'List systems a release is enhanced for or incompatible with'";
 
 // If the update should auto execute without user interaction set to "yes".
 $database_autoexecute = "yes";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_release_resolution_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_release_resolution_table.php
@@ -29,7 +29,7 @@ $database_update_sql = "CREATE TABLE game_release_resolution (
 )
 ENGINE = InnoDB
 CHARSET = utf8
-COMMENT = 'Table used for setting resolutions'";
+COMMENT = 'List screen resolutions supported by a release'";
 
 // If the update should auto execute without user interaction set to "yes".
 $database_autoexecute = "yes";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_resolution_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_resolution_table.php
@@ -20,13 +20,13 @@ AND table_name = 'resolution' LIMIT 1";
 
 // Database change
 $database_update_sql = "CREATE TABLE resolution (
-    `resolution_id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a resolution',
-    `resolution_name` VARCHAR(255) NOT NULL COMMENT 'Name of resolution',
+    `resolution_id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a screen resolution',
+    `resolution_name` VARCHAR(255) NOT NULL COMMENT 'Name of screen resolution',
     PRIMARY KEY (`resolution_id`)
 )
 ENGINE = InnoDB
 CHARSET = utf8
-COMMENT = 'Resolution table used for setting resolutions'";
+COMMENT = 'List all screen resolutions'";
 
 // If the update should auto execute without user interaction set to "yes".
 $database_autoexecute = "yes";


### PR DESCRIPTION
Try to make comment more explicit by avoiding repeating "table used
for..." (since it's a comment on a table, it's already obvious) and
describe what it's used for (rather than just what it stores, which
should already be obvious from the columns).

This is a bit nitpicking, but I think that will be valuable for people
to get familiar with the schema or for ourselves when we'll have forgot
what a table is for in a few months...