### PR TITLE
Changes to release navigation and game editor

### DIFF
--- a/Sources/styles/1/scss/_cpanel-games.scss
+++ b/Sources/styles/1/scss/_cpanel-games.scss
@@ -19,14 +19,28 @@
     width: 100%;
 }
 
+h1 {
+    a {
+        color: #00d3d3;
+    }
+}
+
 //*----------------------------------------------------------
 //Games detail
 //------------------------------------------------------------ */
+
+img.edit-tile {
+    width: 100%;
+}
 
 .gd_navigator {
     button {
         width: 100%;
         margin-left: 0;
+    }
+
+    a {
+        display: block;
     }
 }
 
@@ -230,4 +244,47 @@
 
 .dropdown_show {
     display: block;
+}
+
+//*----------------------------------------------------------
+// Navigation list inside a tile
+//------------------------------------------------------------ */
+ul.navigation-list {
+    list-style-type: none;
+    text-align: left;
+
+    li {
+        padding-top: 5px;
+        padding-bottom: 5px;
+
+        &.active {
+            background-color: #00d3d3;
+
+            a {
+                color: black;
+            }
+
+            small {
+                color: #333;
+            }
+
+            i {
+                color: #666;
+            }
+        }
+    }
+
+    a {
+        color: #00d3d3;
+
+        small {
+            color: #bbb;
+        }
+
+        i {
+            color: white;
+            margin-left: 5px;
+        }
+
+    }
 }

--- a/Sources/styles/1/scss/_form_components.scss
+++ b/Sources/styles/1/scss/_form_components.scss
@@ -141,6 +141,10 @@
     border: 1px solid #122323;
 }
 
+.primary_button a {
+    color: white;
+}
+
 label.primary_button {
     padding-top: 5px;
     padding-bottom: 2.5px;

--- a/Website/AtariLegend/php/admin/games/games_detail.php
+++ b/Website/AtariLegend/php/admin/games/games_detail.php
@@ -25,8 +25,10 @@ include("../../config/admin.php");
 include("../../admin/games/quick_search_games.php");
 
 require_once __DIR__."/../../common/DAO/GameReleaseDAO.php";
+require_once __DIR__."/../../common/DAO/GameDAO.php";
 
 $gameReleaseDao = new \AL\Common\DAO\GameReleaseDAO($mysqli);
+$gameDao = new \AL\Common\DAO\GameDAO($mysqli);
 
 //***********************************************************************************
 //Let's get the general game info first.
@@ -66,6 +68,9 @@ while ($game_info = $sql_game->fetch_array(MYSQLI_BOTH)) {
         'game_stac' => $game_info['stac']
     ));
 }
+
+$smarty->assign('game', $gameDao->getGame($game_id));
+$smarty->assign('game_screenshot', $gameDao->getRandomScreenshot($game_id));
 
 //***********************************************************************************
 //get the release dates
@@ -236,6 +241,22 @@ while ($catcross = $sql_catcross->fetch_array(MYSQLI_BOTH)) {
 }
 
 $smarty->assign("nr_catcross", $nr_catcross);
+
+//***********************************************************************************
+// Game facts
+//***********************************************************************************
+
+$sql_facts = $mysqli->query("SELECT COUNT(*) AS C FROM game_fact WHERE game_id = $game_id") or die($mysqli->error);
+$facts = $sql_facts->fetch_array(MYSQLI_BOTH);
+$smarty->assign('nr_facts', $facts['C']);
+
+//***********************************************************************************
+// Similar games
+//***********************************************************************************
+
+$sql_similar = $mysqli->query("SELECT COUNT(*) AS C FROM game_similar WHERE game_id = $game_id") or die($mysqli->error);
+$similar = $sql_similar->fetch_array(MYSQLI_BOTH);
+$smarty->assign('nr_similar', $similar['C']);
 
 //***********************************************************************************
 //AKA's

--- a/Website/AtariLegend/php/admin/games/games_facts.php
+++ b/Website/AtariLegend/php/admin/games/games_facts.php
@@ -17,6 +17,10 @@ include("../../config/admin.php");
 //load the search fields of the quick search side menu
 include("../../admin/games/quick_search_games.php");
 
+require_once __DIR__."/../../common/DAO/GameDAO.php";
+$gameDao = new \AL\Common\DAO\GameDAO($mysqli);
+$smarty->assign('game', $gameDao->getGame($game_id));
+
 $i=0;
 
 //load the fact for this games
@@ -57,19 +61,14 @@ while ($sql_games_facts = $query_games_facts->fetch_array(MYSQLI_BOTH)) {
         'game_fact_nr' => $i,
         'game_fact' => $fact_text
     ));
-    
-    if (isset($game_name)){     
+
+    if (isset($game_name)){
     }else{
         $smarty->assign('game_name', $sql_games_facts['game_name']);
     }
 }
 
-if (isset($game_name)){    
-    $smarty->assign('game_name', $game_name);
-}
-
 $smarty->assign('game_id', $game_id);
-
 
 //Send all smarty variables to the templates
 $smarty->display("file:" . $cpanel_template_folder . "games_facts.html");

--- a/Website/AtariLegend/php/common/DAO/GameDAO.php
+++ b/Website/AtariLegend/php/common/DAO/GameDAO.php
@@ -39,4 +39,31 @@ class GameDAO {
 
         return $game;
     }
+
+    public function getRandomScreenshot($game_id) {
+        $stmt = \AL\Db\execute_query(
+            "GameDAO: getRandomScreenshot: $game_id",
+            $this->mysqli,
+            "SELECT screenshot_game.screenshot_id, imgext FROM screenshot_game
+            LEFT JOIN screenshot_main ON (screenshot_game.screenshot_id  = screenshot_main.screenshot_id)
+            WHERE screenshot_game.game_id = ?
+            ORDER BY RAND() LIMIT 1",
+            "i", $game_id
+        );
+
+        \AL\Db\bind_result(
+            "GameDAO: getRandomScreenshot: $game_id",
+            $stmt,
+            $screenshot_id, $imgext
+        );
+
+        $screenshot = null;
+        if ($stmt->fetch()) {
+            $screenshot = $screenshot_id.".".$imgext;
+        }
+
+        $stmt->close();
+
+        return $GLOBALS['game_screenshot_path']."/".$screenshot;
+    }
 }

--- a/Website/AtariLegend/themes/templates/1/admin/games_detail.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_detail.html
@@ -21,108 +21,43 @@
 *}
 {extends file='1/admin/main.html'}
 {block name=left_tile}
+    {include file='1/admin/games_detail_editing.html'}
+    <br>
+
+    {include file='1/admin/games_release_list.html'}
+    <br>
+
     {include file='1/admin/quick_search_games.html'}
 {/block}
+
 {block name=right_tile}
 
-
-<div class="standard_tile text-center">
-    <h1>OTHER FEATURES</h1>
-    <div class="standard_tile_line"></div>
-    <div class="standard_tile_padding">
-        <div class="gd_navigator">
-            <button id="comments_all" class="primary_button">Add file download</button><br>
-            <button id="comments_game_comments" class="primary_button">Add game facts</button><br>
-            <button id="comments_game_review_comments" class="primary_button">Add screenshots</button><br>
-            <button id="comments_interview_comments" class="primary_button">Add Mag review score</button><br>
-            <button id="test_clicker" class="primary_button">Add boxscans</button><br>
-            <button id="similar_games_link" class="primary_button">Add Similar Games</button><br>
-            <button id="write_review_link" class="primary_button">Write a review</button><br>
-            <button id="moderate_comments_link" class="primary_button">Moderate comments</button><br>
-        </div>
-        <div style="display:none;">
-        <a href="../downloads/downloads_game_detail.php?game_id={$game_info.game_id}" class="left_nav_link">Add file download</a><br>
-        <a href="../games/games_facts.php?game_id={$game_info.game_id}&amp;game_name={$game_info.game_name}" class="left_nav_link">Add game facts</a><br>
-        <a href="../games/games_screenshot_add.php?game_id={$game_info.game_id}&amp;game_name={$game_info.game_name}" class="left_nav_link">Add screenshots</a><br>
-        <a href="../magazine/magazine_review_score.php?game_id={$game_info.game_id}&amp;game_name={$game_info.game_name}" class="left_nav_link">Add Mag review score</a><br>
-        <a href="../games/games_box.php?game_id={$game_info.game_id}&amp;game_name={$game_info.game_name}" class="left_nav_link">Add boxscans</a><br>
-        <a href="../games/games_similar.php?game_id={$game_info.game_id}&amp;game_name={$game_info.game_name}" class="left_nav_link">Add Similar Games</a><br>
-        <a href="../games/games_review_add.php?game_id={$game_info.game_id}" class="left_nav_link">Write a review</a><br>
-        {if $nr_comments > 0}
-            <br>
-            <a href="../games/games_comment.php?game_id={$game_info.game_id}&amp;view=game_comments" class="left_nav_link">Moderate comments</a>
-        {/if}
-        </div>
-
-
-
-        <br>
-    </div>
-</div>
-<br>
-
-<div class="standard_tile text-center">
-    <h1>STATISTICS</h1>
-    <div class="standard_tile_line"></div>
-    <div class="standard_tile_padding">
-        <div class="standard_tile_text_center">
-            Nr of Screenshots - {$nr_screenshots}<br>
-            Nr of Box scans - {$nr_boxscans}<br>
-            Nr of reviews - {$nr_reviews}<br>
-            Nr of entries in Gallery - {$nr_pics}<br>
-            Nr of music files - {$nr_music}<br>
-            Nr of magazine reviews - {$nr_magazines}<br>
+    <div class="standard_tile text-center">
+        <h1>MORE DATA</h1>
+        <div class="standard_tile_line"></div>
+        <div class="standard_tile_padding">
+            <div class="gd_navigator">
+                <!--
+                <a href="../downloads/downloads_game_detail.php?game_id={$game->getId()}" class="primary_button">Add file download</a>
+                -->
+                <a href="../games/games_facts.php?game_id={$game->getId()}" class="primary_button">Game facts <span class="help-hint">({$nr_facts})</span></a>
+                <a href="../games/games_screenshot_add.php?game_id={$game->getId()}" class="primary_button">Screenshots <span class="help-hint">({$nr_screenshots})</span></a>
+                <a href="../magazine/magazine_review_score.php?game_id={$game->getId()}" class="primary_button">Mag review scores <span class="help-hint">({$nr_magazines})</span></a>
+                <a href="../games/games_box.php?game_id={$game->getId()}" class="primary_button">Boxscans <span class="help-hint">({$nr_boxscans})</span></a>
+                <a href="../games/games_similar.php?game_id={$game->getId()}" class="primary_button">Similar Games <span class="help-hint">({$nr_similar})</span></a>
+                <a href="../games/games_review.php?game_id={$game->getId()}" class="primary_button">Reviews <span class="help-hint">({$nr_reviews})</span></a>
+                {if $nr_comments > 0}
+                    <a href="../games/games_comment.php?game_id={$game->getId()}" class="primary_button">Moderate comments</a>
+                {/if}
+            </div>
             <br>
         </div>
     </div>
-</div>
-<br>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    <br>
     {include file='1/main/tile_bug_report.html'}
 {/block}
 {block name=java_script}
 <script>
-
-function deletegame(game_id) {
-    $('#JSGenericModal').dialog({
-        title: 'Delete Game',
-        open: $('#JSGenericModalText').text('Are you sure you want to delete this game?'),
-        resizable: false,
-        height: 200,
-        modal: true,
-        buttons: {
-            'Delete': function () {
-                $(this).dialog('close');
-                url="../games/db_games_detail.php?game_id="+game_id+"&action=delete_game";
-                location.href=url;
-            },
-            Cancel: function () {
-                $(this).dialog('close');
-            }
-        }
-    });
-}
 
 function delete_publisher() {
     document.getElementById('publisher').method="post";
@@ -159,21 +94,6 @@ function add_creator() {
     document.getElementById('creator').action="../games/db_games_detail.php?action=add_creator";
     document.getElementById('creator').submit();
 }
-
-function delete_release()
-{
-    document.getElementById('year').method="post";
-    document.getElementById('year').action="../games/db_games_detail.php?action=delete_release";
-    document.getElementById('year').submit();
-}
-
-function add_release()
-{
-    document.getElementById('year').method="post";
-    document.getElementById('year').action="../games/db_games_detail.php?action=add_release";
-    document.getElementById('year').submit();
-}
-
 
 function browseCompany(str) {
     if (str == "") {
@@ -233,61 +153,21 @@ $('#input-tags3').selectize({
         <div class="standard_tile_padding">
             <fieldset class="secondary_fieldset">
                 <legend class="primary_legend">Basic game info - help</legend>
-                        Overhere you can add additional game info. Just select what you think is neceasrry, and press the modify button to link it all to the game.
+                        Overhere you can add additional game info. Just select what you think is necessary, and press the modify button to link it all to the game.
                         When you press the delete button, the complete game and all table entries linked to this game entity will be removed from the database!
             </fieldset>
             <br>
             <div>
-
-
-
-
-
-
-
-
-                <div class="comments_post_box" id="">
-                    <div class="comments_userinfo">
-
-                        <img src="../../includes/show_image.php?file=../../data/images/game_screenshots/659.png&amp;resize=320,null,null,null" alt="" width="320px">
-
-                        <a href="../user/user_detail.php" class="links_addnew_link">{$game_info.game_name}</a>
-
-                        <br><br><br>
-                        <span class="text-nowrap">
-                            {$nr_screenshots} Screenshots<br>
-                            {$nr_boxscans} Box scans<br>
-                            {$nr_reviews} Reviews<br>
-                            {$nr_pics} Gallery images<br>
-                            {$nr_music} music files<br>
-                            {$nr_magazines} magazine reviews<br>
-                            <br>
-                            <br>
-
-                        </span>
-                    </div>
-
+                <div class="comments_post_box">
                     <div class="comment_post_detail">
-                        <div class="comments_userinfo_phoneview">
-
-                                <img src="../../includes/show_image.php?file=../../data/images/game_screenshots/659.png&amp;resize=320,null,null,null" alt="" width="320px">
-
-                            <h6>
-                                <a href="../user/user_detail.php" class="links_addnew_link">{$game_info.game_name}</a>
-                            </h6>
-                        </div>
                         <h4 class="comments_title">
                                 Basic game info
                         </h4>
                         <ul class="comment_buttons">
-                            <li class="primary_button jsCommentsEditButton" data-comments-id="{$game_info.game_id}" data-comment-type="{$game_info.game_id}">
-                                <a class="links_addnew_link">
-                                        <i class="fa fa-pencil" aria-hidden="true"></i>
-                                </a>
-                            </li>
-                            <li class="primary_button jsCommentsDeleteButton" data-comments-id="{$game_info.game_id}">
-                                <a class="links_addnew_link">
-                                        <i class="fa fa-trash" aria-hidden="true"></i>
+                            <li class="primary_button">
+                                <a href="../games/db_games_detail.php?game_id={$game->getId()}&amp;action=delete_game"
+                                    onclick="javascript:return confirm('The game will be deleted')">
+                                    <i class="fa fa-trash" aria-hidden="true"></i>
                                 </a>
                             </li>
                             <div class="comments_button_dropdown" data-dropdown-id="{$game_info.game_id}">
@@ -297,9 +177,6 @@ $('#input-tags3').selectize({
                                     </a>
                                 </li>
                                 <div class="dropdown_box" id="dropdown_box{$game_info.game_id}">
-                                    <li class="dropdown_item jsCommentsEditDropdownItem" data-comments-id="{$game_info.game_id}" data-comment-type="{$game_info.game_id}">
-                                        Edit
-                                    </li>
                                     <li class="dropdown_item jsCommentsDeleteDropdownItem" data-comments-id="{$game_info.game_id}">
                                         Delete
                                     </li>
@@ -307,126 +184,139 @@ $('#input-tags3').selectize({
                             </div>
                         </ul>
                         <div class="comments_line" id="line_above_info"></div>
-                        <h4 class="comments_title_phoneview">
-                                Basic game info
-                        </h4>
-                        <div class="comments_post_info">
-                            Last updated <span>by <a href="../user/user_detail.php?user_id_selected=">Silver Surfer</a></span> on November 30, 2017
-                        </div>
-                        <div class="comments_line" id="line_below_info"></div>
-                        <div class="comment_post_text" id="jsCommentTextBox{$game_info.game_id}">
-                            <br>
-                            <b>Game name :</b> <input type="text" maxlength="255" name="game_name" value="{$game_info.game_name}" class="standard_input input_large">
-                            <br>
-
-                            <br>
-                            <div id="gd_basic_game_info_1">
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="unreleased" name="unreleased" value="1" {if $game_info.game_unreleased == 1} checked{/if}>
-                                            <label for="unreleased"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">Unreleased&nbsp;</div>
-                                </div>
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="development" name="development" value="1" {if $game_info.game_development == 1} checked{/if}>
-                                            <label for="development"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">In development&nbsp;</div>
-                                </div>
-
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="unfinished" name="unfinished" value="1" {if $game_info.game_unfinished == 1} checked{/if}>
-                                            <label for="unfinished"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">Unfinished&nbsp;</div>
-                                </div>
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="wanted" name="wanted" value="1" {if $game_info.game_wanted <> ''} checked{/if}>
-                                            <label for="wanted"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">Wanted&nbsp;</div>
-                                </div>
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="arcade" name="arcade" value="1" {if $game_info.game_arcade == 1} checked{/if}>
-                                            <label for="arcade"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">Arcade conversion&nbsp;</div>
-                                </div>
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="seuck" name="seuck" value="1" {if $game_info.game_seuck == 1} checked{/if}>
-                                            <label for="seuck"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">SEUCK game&nbsp;</div>
-                                </div>
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="stos" name="stos" value="1" {if $game_info.game_stos == 1} checked{/if}>
-                                            <label for="stos"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">STOS game&nbsp;</div>
-                                </div>
-                                <div class="gd_basic_game_info_row">
-                                    <div class="gd_basic_game_info_row_check">
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="stac" name="stac" value="1" {if $game_info.game_stac == 1} checked{/if}>
-                                            <label for="stac"></label>
-                                        </div>
-                                    </div>
-                                    <div class="gd_basic_game_info_row_checktxt">STAC game&nbsp;</div>
-                                </div>
+                        <form action="../games/db_games_detail.php" method="post" name="edit">
+                            <input type="hidden" name="game_id" value="{$game->getId()}">
+                            <input type="hidden" name="action" value="modify_game">
+                            <h4 class="comments_title_phoneview">
+                                    Basic game info
+                            </h4>
+                            <div class="comments_post_info">
+                                Last updated <span>by <a href="../user/user_detail.php?user_id_selected=">Silver Surfer</a></span> on November 30, 2017
                             </div>
-                            <br>
-                            <br>
-                        </div>
-                        <div class="demo">
-                        <b>Category</b>
+                            <div class="comments_line" id="line_below_info"></div>
+                            <div class="comment_post_text" id="jsCommentTextBox{$game_info.game_id}">
+                                <br>
+                                <b>Game name :</b> <input type="text" maxlength="255" name="game_name" value="{$game_info.game_name}" class="standard_input input_large">
+                                <br>
+
+                                <br>
+                                <div id="gd_basic_game_info_1">
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="unreleased" name="unreleased" value="1" {if $game_info.game_unreleased == 1} checked{/if}>
+                                                <label for="unreleased"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">Unreleased&nbsp;</div>
+                                    </div>
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="development" name="development" value="1" {if $game_info.game_development == 1} checked{/if}>
+                                                <label for="development"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">In development&nbsp;</div>
+                                    </div>
+
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="unfinished" name="unfinished" value="1" {if $game_info.game_unfinished == 1} checked{/if}>
+                                                <label for="unfinished"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">Unfinished&nbsp;</div>
+                                    </div>
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="wanted" name="wanted" value="1" {if $game_info.game_wanted <> ''} checked{/if}>
+                                                <label for="wanted"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">Wanted&nbsp;</div>
+                                    </div>
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="arcade" name="arcade" value="1" {if $game_info.game_arcade == 1} checked{/if}>
+                                                <label for="arcade"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">Arcade conversion&nbsp;</div>
+                                    </div>
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="seuck" name="seuck" value="1" {if $game_info.game_seuck == 1} checked{/if}>
+                                                <label for="seuck"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">SEUCK game&nbsp;</div>
+                                    </div>
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="stos" name="stos" value="1" {if $game_info.game_stos == 1} checked{/if}>
+                                                <label for="stos"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">STOS game&nbsp;</div>
+                                    </div>
+                                    <div class="gd_basic_game_info_row">
+                                        <div class="gd_basic_game_info_row_check">
+                                            <div class="links_mod_checkbox">
+                                                <input type="checkbox" id="stac" name="stac" value="1" {if $game_info.game_stac == 1} checked{/if}>
+                                                <label for="stac"></label>
+                                            </div>
+                                        </div>
+                                        <div class="gd_basic_game_info_row_checktxt">STAC game&nbsp;</div>
+                                    </div>
+                                </div>
+                                <br>
+                                <br>
+                            </div>
+                            <div class="demo">
+                            <b>Category</b>
                             <div class="control-group">
-                            <label for="input-tags"></label>
-                            <select name="category[]" multiple id="input-tags" class="standard_select" size="1">
-                            {foreach from=$cat item=line}
-                                <option value="{$line.cat_id}" {$line.cat_selected}>{$line.cat_name}</option>
-                            {/foreach}
-                            </select>
+                                <label for="input-tags"></label>
+                                <select name="category[]" multiple id="input-tags" class="standard_select" size="1">
+                                {foreach from=$cat item=line}
+                                    <option value="{$line.cat_id}" {$line.cat_selected}>{$line.cat_name}</option>
+                                {/foreach}
+                                </select>
                             </div>
                             <script>
-                            $('#input-tags').selectize({
-                            plugins: ['remove_button'],
-                            persist: false,
-                            create: true,
-                            render: {
-                                item: function(data, escape) {
-                            return '<div class="primary_button" style="border-radius:5px;">' + escape(data.text) + '</div>';
-                            }
-                            },
-                            onDelete: function(values) {
-                            return confirm(values.length > 1 ? 'Are you sure you want to remove these ' + values.length + ' items?' : 'Are you sure you want to remove "' + values[0] + '"?');
-                            }
-                            });
+                                $('#input-tags').selectize({
+                                plugins: ['remove_button'],
+                                persist: false,
+                                create: true,
+                                render: {
+                                    item: function(data, escape) {
+                                return '<div class="primary_button" style="border-radius:5px;">' + escape(data.text) + '</div>';
+                                }
+                                },
+                                onDelete: function(values) {
+                                return confirm(values.length > 1 ? 'Are you sure you want to remove these ' + values.length + ' items?' : 'Are you sure you want to remove "' + values[0] + '"?');
+                                }
+                                });
                             </script>
-                        </div>
+                            </div>
+
+                            <input type="submit" name="valider" value="Modify" class="secondary_button">
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div>
+                <div class="comments_post_box">
+                    <div>
                         <br>
                         <div class="comments_line"></div>
                         <br>
+
                         <b>Development info - help</b><br>
                         You can add as many developers/creators as you like to a game.
                         Use the continent dropdown for example to add in which part of the world
@@ -539,200 +429,103 @@ $('#input-tags3').selectize({
                             <input type="hidden" name="game_id" value="{$game_id}">
                             <input type="button" value="Add" onclick="add_developer()" class="secondary_button">
                         </form>
-                        <br><br><br><br><br>
-
-
-
-
+                        <br>
                     </div>
                 </div>
-
-
-
-
-
-                <br><br><br><br><br>
-
-
-
-
-
-            </div>
-
-
-
-
-
-
-
-
-
-
-            <div>
-
-
-            <div id="gd_releases_info">
-                <fieldset class="secondary_fieldset">
-                <legend class="primary_legend">Releases info - help</legend>
-                    The releases section is used to add information about different releases.
-                    Different releases can be different officially published releases and also
-                    various fan made modifications, hacks, cracks etc
-                </fieldset>
                 <br>
             </div>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-                    <div id="gd_release_year">
-                        <form action="../games/db_games_detail.php" method="post" name="year" id="year">
-                            <fieldset class="secondary_fieldset">
-                                <legend class="primary_legend">Releases <small>({count($game_releases)})</small></legend>
-                                    {foreach from=$game_releases item=release}
-                                        <div class="links_mod_checkbox">
-                                            <input type="checkbox" id="release-{$release->getId()}" name="game_release_id[]" value="{$release->getId()}">
-                                            <label for="release-{$release->getId()}"></label>&nbsp;
-                                            <a href="games_release_detail.php?release_id={$release->getId()}">
-                                            {if $release->getDate() != null}
-                                                {$release->getDate()|date_format:"%Y"}
-                                            {else}
-                                                (release with no date set)
-                                            {/if}
-                                            {if $release->getName() != null}<b>({$release->getName()})</b>{/if}
-                                            </a>
-                                        </div>
-                                    {/foreach}
-                                    {if count($game_releases) gt 1}
-                                        <img src="../../../themes/templates/1/includes/img/arrow_ltr.gif" alt="" width="38" height="22" style="display:inline;">
-                                        <input type="button" name="valider" value="Delete" onclick="delete_release()" class="secondary_button" style="display:inline;">
-                                        <br/><br/>
-                                    {elseif count($game_releases) eq 1}
-                                        <small class="help-hint">This game has a single release which cannot be deleted. To delete this release, create a new one first. All games must have at least one release.</small>
-                                        <br><br>
-                                    {else}
-                                        <small>This game has no releases yet</small>
-                                        <br><br>
-                                    {/if}
-                                    {html_select_date start_year=1984 display_days=0 display_months=0 class="standard_select"}
-                                    <b>Release Year</b>
-                                    <br>
-                                    <input type="text" placeholder="Alt. title (optional)" name="release_name" class="standard_input">
-                                    <br><br>
-                                    <input type="hidden" name="game_id" value="{$game_id}">
-                                    <input type="button" value="Add" onclick="add_release()" class="secondary_button">
-                            </fieldset>
-                        </form>
-                        <br>
-                    </div>
-                    <div>
-                    </div>
-
-                    <div id="gd_game_aka">
-                        <form action="../games/db_games_detail.php" method="post" name="aka" id="aka">
-                        <fieldset class="secondary_fieldset">
-                            <legend class="primary_legend">Add game AKA</legend>
-                            <b>Game AKA :</b> <input type="text" name="game_aka"  class="standard_input input_large">
-                            <br>
-                            <br>
-                            <input type="submit" name="valider" value="Add" class="secondary_button">
-                            <input type="hidden" name="action" value="game_aka">
-                            <input type="hidden" name="game_id" value="{$game_id}">
-                            {if $nr_aka <> 0}
-                                <br>
-                                <br>
-                                <b>Current AKA</b>
-                                <br>
-                                {foreach from=$aka item=line}
-                                    <a href="../games/games_detail.php?game_id={$line.game_id}" class="left_nav_link">
-                                        {$line.game_aka_name}
-                                    </a> - <b>
-                                    <a href="../games/db_games_detail.php?game_aka_id={$line.game_aka_id}&action=delete_aka&game_id={$line.game_id}" class="left_nav_link">delete</a></b>
-                                    <br>
-                                {/foreach}
-                            {/if}
-                        </fieldset>
-                        </form>
-                    </div>
-
-                    <div id="gd_publisher_info">
+            <div>
+                <div id="gd_game_aka">
+                    <form action="../games/db_games_detail.php" method="post" name="aka" id="aka">
                     <fieldset class="secondary_fieldset">
-                        <legend class="primary_legend">Publisher info</legend>
-                        <form action="../games/db_games_detail.php" method="post" name="publisher" id="publisher">
-                            {if isset($publisher)}
-                                {foreach from=$publisher item=line}
-                                    <div class="links_mod_checkbox">
-                                        <input type="checkbox" id="game_publisher_id[{$line.pub_id}]" name="game_publisher_id[]" value="{$line.pub_id}">
-                                        <label for="game_publisher_id[{$line.pub_id}]"></label>&nbsp;
-                                        <a href="../company/company_edit.php?comp_id={$line.pub_id}" class="left_nav_link">{$line.pub_name}</a> {if $line.continent <> '' }<b>({$line.continent})</b>{/if} {if  $line.extra_info <> '' }<b>({$line.extra_info})</b>{/if}
-                                    </div>
-                                    <br>
-                                {/foreach}
-                                <img src="../../../themes/templates/1/includes/img/arrow_ltr.gif" alt="" width="38" height="22" style="display:inline;">
-                                <input type="button" name="valider" value="Delete" onclick="delete_publisher()" class="secondary_button" style="display:inline;">
-                                <br>
-                                <br>
-                            {/if}
-                            <table>
-                            <tr>
-                                <td>
-                                    <select name="companybrowse" onchange="browseCompany(this.value)" class="standard_select select_small">
-                                        <option value="" SELECTED>-</option>
-                                        {html_options values=$az_value output=$az_output}
-                                    </select>
-                                </td>
-                                <td>
-                                    <div id="ajax_publisher_browse">
-                                        <select name="company_id_pub" class="standard_select select_medium">
-                                            <option value="-" selected="selected">-</option>
-                                            {foreach from=$company item=line}
-                                                <option value="{$line.comp_id}">{$line.comp_name}</option>
-                                            {/foreach}
-                                        </select>
-                                    </div>
-                                </td>
-                                <td>
-                                    <b>Name</b>
-                                </td>
-                            </tr>
-                            </table>
+                        <legend class="primary_legend">Add game AKA</legend>
+                        <b>Game AKA :</b> <input type="text" name="game_aka"  class="standard_input input_large">
+                        <br>
+                        <br>
+                        <input type="submit" name="valider" value="Add" class="secondary_button">
+                        <input type="hidden" name="action" value="game_aka">
+                        <input type="hidden" name="game_id" value="{$game_id}">
+                        {if $nr_aka <> 0}
                             <br>
-                            <select name="continent_pub" class="standard_select select_medium">
-                                <option value="-" selected="selected">-</option>
-                                {foreach from=$continent item=line}
-                                    <option value="{$line.continent_id}">{$line.continent_name}</option>
-                                {/foreach}
-                            </select>
-                            <b>Continent</b>
                             <br>
-                            <select name="game_extra_info_pub" class="standard_select select_medium">
-                                <option value="-" selected="selected">-</option>
-                                {foreach from=$game_extra_info item=line}
-                                    <option value="{$line.game_extra_info_id}">{$line.game_extra_info}</option>
-                                {/foreach}
-                            </select>
-                            <b>Extra Info</b>
-                            <br><br>
-                            <input type="hidden" name="game_id" value="{$game_id}">
-                            <input type="button" value="Add" onclick="add_publisher()" class="secondary_button">
-                        </form>
+                            <b>Current AKA</b>
+                            <br>
+                            {foreach from=$aka item=line}
+                                <a href="../games/games_detail.php?game_id={$line.game_id}" class="left_nav_link">
+                                    {$line.game_aka_name}
+                                </a> - <b>
+                                <a href="../games/db_games_detail.php?game_aka_id={$line.game_aka_id}&action=delete_aka&game_id={$line.game_id}" class="left_nav_link">delete</a></b>
+                                <br>
+                            {/foreach}
+                        {/if}
                     </fieldset>
-                    </div>
-
-
-
-
-
-
+                    </form>
+                </div>
+                <br>
+                <div id="gd_publisher_info">
+                <fieldset class="secondary_fieldset">
+                    <legend class="primary_legend">Publisher info</legend>
+                    <form action="../games/db_games_detail.php" method="post" name="publisher" id="publisher">
+                        {if isset($publisher)}
+                            {foreach from=$publisher item=line}
+                                <div class="links_mod_checkbox">
+                                    <input type="checkbox" id="game_publisher_id[{$line.pub_id}]" name="game_publisher_id[]" value="{$line.pub_id}">
+                                    <label for="game_publisher_id[{$line.pub_id}]"></label>&nbsp;
+                                    <a href="../company/company_edit.php?comp_id={$line.pub_id}" class="left_nav_link">{$line.pub_name}</a> {if $line.continent <> '' }<b>({$line.continent})</b>{/if} {if  $line.extra_info <> '' }<b>({$line.extra_info})</b>{/if}
+                                </div>
+                                <br>
+                            {/foreach}
+                            <img src="../../../themes/templates/1/includes/img/arrow_ltr.gif" alt="" width="38" height="22" style="display:inline;">
+                            <input type="button" name="valider" value="Delete" onclick="delete_publisher()" class="secondary_button" style="display:inline;">
+                            <br>
+                            <br>
+                        {/if}
+                        <table>
+                        <tr>
+                            <td>
+                                <select name="companybrowse" onchange="browseCompany(this.value)" class="standard_select select_small">
+                                    <option value="" SELECTED>-</option>
+                                    {html_options values=$az_value output=$az_output}
+                                </select>
+                            </td>
+                            <td>
+                                <div id="ajax_publisher_browse">
+                                    <select name="company_id_pub" class="standard_select select_medium">
+                                        <option value="-" selected="selected">-</option>
+                                        {foreach from=$company item=line}
+                                            <option value="{$line.comp_id}">{$line.comp_name}</option>
+                                        {/foreach}
+                                    </select>
+                                </div>
+                            </td>
+                            <td>
+                                <b>Name</b>
+                            </td>
+                        </tr>
+                        </table>
+                        <br>
+                        <select name="continent_pub" class="standard_select select_medium">
+                            <option value="-" selected="selected">-</option>
+                            {foreach from=$continent item=line}
+                                <option value="{$line.continent_id}">{$line.continent_name}</option>
+                            {/foreach}
+                        </select>
+                        <b>Continent</b>
+                        <br>
+                        <select name="game_extra_info_pub" class="standard_select select_medium">
+                            <option value="-" selected="selected">-</option>
+                            {foreach from=$game_extra_info item=line}
+                                <option value="{$line.game_extra_info_id}">{$line.game_extra_info}</option>
+                            {/foreach}
+                        </select>
+                        <b>Extra Info</b>
+                        <br><br>
+                        <input type="hidden" name="game_id" value="{$game_id}">
+                        <input type="button" value="Add" onclick="add_publisher()" class="secondary_button">
+                    </form>
+                </fieldset>
+                </div>
             </div>
             <div id="gd_bottom">
                 <div id="gd_back">

--- a/Website/AtariLegend/themes/templates/1/admin/games_detail_editing.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_detail_editing.html
@@ -1,0 +1,11 @@
+<div class="standard_tile text-center">
+    <h1>EDITING <a href="games_detail.php?game_id={$game->getId()}">{$game->getName()}</a></h1>
+    <div class="standard_tile_line"></div>
+    <div class="standard_tile_padding">
+        <a href="games_detail.php?game_id={$game->getId()}">
+            <img class="edit-tile" src="../../includes/show_image.php?file={$game_screenshot}" >
+        </a>
+        <br>
+        <small class="help-hint">(random screenshot)</small>
+    </div>
+</div>

--- a/Website/AtariLegend/themes/templates/1/admin/games_facts.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_facts.html
@@ -31,7 +31,7 @@
             remove a fact and its screenshots from the DB. More facts can be added to a game.
         </p>
     </div>
-    <h1>{$game_name|upper}</h1>
+    <h1>{$game->getName()|upper}</h1>
     <div class="standard_tile_line"></div>
     <div class="standard_tile_padding">
         <div class="left_nav_section">
@@ -56,7 +56,7 @@
                 <br><br>
                 <input type="hidden" name="action" value="game_fact_insert">
                 <input type="hidden" name="game_id" value="{$game_id}">
-                <input type="hidden" name="game_name" value="{$game_name}">
+                <input type="hidden" name="game_name" value="{$game->getName()}">
                 <input type="submit" value="Submit" class="secondary_button">
             </fieldset>
         </form>

--- a/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
@@ -1,54 +1,72 @@
+{block name=left_tile}
+    {include file='1/admin/games_detail_editing.html'}
+    <br>
+
+    {include file='1/admin/games_release_list.html'}
+{/block}
+
 {extends file='1/admin/main.html'} {block name=main_tile}
 <div class="standard_tile">
     {if isset ($release)}
-        <h1>Release for
+        <h1>
+            {if $release->getDate()}{$release->getDate()|date_format:"%Y"}{/if}
+            Release for
             <a href="games_detail.php?game_id={$game->getId()}">{$game->getName()}</a>
         </h1>
-        <div class="standard_tile_line"></div>
+    {else}
+    <h1>Add a new release for
+            <a href="games_detail.php?game_id={$game->getId()}">{$game->getName()}</a>
+        </h1>
+    {/if}
+
+    <div class="standard_tile_line"></div>
+    <div class="standard_tile_padding">
+        <fieldset class="secondary_fieldset">
+            <legend class="primary_legend">Editing a release</legend>
+            Each game can have multiple releases. A release has a date and different features, such as the fact that it was enhanced
+            for a system (e.g. STe) or incompatible with others (e.g. Falcon).
+        </fieldset>
+    </div>
+
+    <form method="POST">
+        <input type="hidden" name="game_id" value="{$game->getId()}">
+        <input type="hidden" name="release_id" value="{$release->getId()}">
         <div class="standard_tile_padding">
             <fieldset class="secondary_fieldset">
-                <legend class="primary_legend">Editing a release</legend>
-                Each game can have multiple releases. A release has a date and different features, such as the fact that it was enhanced
-                for a system (e.g. STe) or incompatible with others (e.g. Falcon).
-            </fieldset>
-        </div>
+                <legend class="primary_legend">Release attributes</legend>
 
-        <form method="POST">
-            <input type="hidden" name="release_id" value="{$release->getId()}">
-            <div class="standard_tile_padding">
-                <fieldset class="secondary_fieldset">
-                    <legend class="primary_legend">Release attributes</legend>
+                Release date: {html_select_date time=$release->getDate() year_empty="Unknown" start_year=1984 display_days=0 display_months=0 class="standard_select"}<br>
 
-                    Release date: {html_select_date time=$release->getDate() start_year=1984 display_days=0 display_months=0 class="standard_select"}<br>
+                Alternative title (optional): <input type="text" name="name" class="standard_input" value="{$release->getName()}">
+                <span class="help-hint">(e.g.: Translated title if it's a country-specific release. Leave blank if the title is the same as the game.)</span>
+                <br>
 
-                    Alternative title (optional): <input type="text" name="name" class="standard_input" value="{$release->getName()}">
-                    <span class="help-hint">(e.g.: Translated title if it's a country-specific release. Leave blank if the title is the same as the game.)</span>
-                    <br>
-
-                    License:
-                    <select name="license" class="standard_select">
-                        {foreach from=$license_types item=type}
-                        {$type}
-                        <option {if $type == $release->getLicense()}selected{/if}>{$type}</option>
-                        {/foreach}
-                    </select>
-                    <br><br>
-                    <h4>Screen resolution:</h4>
-                    {foreach from=$resolutions item=resolution}
-                        <div class="checkbox links_mod_checkbox">
-                            <input type="checkbox"
-                                id="resolution_{$resolution->getId()}"
-                                name="resolution[]"
-                                {if in_array($resolution->getId(), $release_resolutions)}checked{/if}
-                                value="{$resolution->getId()}">
-                            <label for="resolution_{$resolution->getId()}"></label>
-                            &nbsp;{$resolution->getName()}<br>
-                        </div>
+                License:
+                <select name="license" class="standard_select">
+                    {foreach from=$license_types item=type}
+                    {$type}
+                    <option {if $type == $release->getLicense()}selected{/if}>{$type}</option>
                     {/foreach}
-                    <br>
+                </select>
+                <br><br>
+                <h4>Screen resolution:</h4>
+                {foreach from=$resolutions item=resolution}
+                    <div class="checkbox links_mod_checkbox">
+                        <input type="checkbox"
+                            id="resolution_{$resolution->getId()}"
+                            name="resolution[]"
+                            {if in_array($resolution->getId(), $release_resolutions)}checked{/if}
+                            value="{$resolution->getId()}">
+                        <label for="resolution_{$resolution->getId()}"></label>
+                        &nbsp;{$resolution->getName()}<br>
+                    </div>
+                {/foreach}
+                <br>
 
-                    <h4>Enhanced for:</h4>
-                    {foreach from=$systems item=system}
+                <h4>Enhanced for:</h4>
+                {foreach from=$systems item=system}
+                    {* Nothing is ever enhanced for the base ST *}
+                    {if $system->getName() != 'ST'}
                         <div class="checkbox links_mod_checkbox">
                             <input type="checkbox"
                                 id="system_enhanced_{$system->getId()}"
@@ -58,46 +76,31 @@
                             <label for="system_enhanced_{$system->getId()}"></label>
                             &nbsp;{$system->getName()}<br>
                         </div>
-                    {/foreach}
-                    <br>
-
-                    <h4>Incompatible with:</h4>
-                    {foreach from=$systems item=system}
-                        <div class="checkbox links_mod_checkbox">
-                            <input type="checkbox"
-                                id="system_incompatible_{$system->getId()}"
-                                name="system_incompatible[]"
-                                {if in_array($system->getId(), $system_incompatible)}checked{/if}
-                                value="{$system->getId()}">
-                            <label for="system_incompatible_{$system->getId()}"></label>
-                            &nbsp;{$system->getName()}<br>
-                        </div>
-                    {/foreach}
-                    <br>
-
-                    <button type="submit" name="submit_type" value="save_and_back" class="primary_button">Save and go back to '{$game->getName()}'</button>
-                    <button type="submit" name="submit_type" value="save" class="secondary_button">Save changes</button>
-                    <a href="games_detail.php?game_id={$game->getId()}">Cancel</a>
-
-                </fieldset>
+                    {/if}
+                {/foreach}
                 <br>
-            </div>
-        </form>
 
-    {else}
-        <div class="standard_tile_line"></div>
-        <div class="standard_tile_padding">
-            <div class="left_nav_section">
-                Release not found
-            </div>
+                <h4>Incompatible with:</h4>
+                {foreach from=$systems item=system}
+                    <div class="checkbox links_mod_checkbox">
+                        <input type="checkbox"
+                            id="system_incompatible_{$system->getId()}"
+                            name="system_incompatible[]"
+                            {if in_array($system->getId(), $system_incompatible)}checked{/if}
+                            value="{$system->getId()}">
+                        <label for="system_incompatible_{$system->getId()}"></label>
+                        &nbsp;{$system->getName()}<br>
+                    </div>
+                {/foreach}
+                <br>
+
+                <button type="submit" name="submit_type" value="save_and_back" class="primary_button">Save and go back to '{$game->getName()}'</button>
+                <button type="submit" name="submit_type" value="save" class="secondary_button">Save changes</button>
+                <a href="games_detail.php?game_id={$game->getId()}">Cancel</a>
+
+            </fieldset>
+            <br>
         </div>
-        <div id="gd_bottom">
-            <div id="gd_back">
-                <div class="standard_tile_text_center">
-                    <a href="javascript:history.go(-1)" class="standard_tile_link">back</a>
-                </div>
-            </div>
-        </div>
-    {/if}
+    </form>
 </div>
 {/block}

--- a/Website/AtariLegend/themes/templates/1/admin/games_release_list.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_release_list.html
@@ -1,0 +1,34 @@
+<div class="standard_tile text-center">
+    <h1>RELEASES <span class="help-hint">({count($game_releases)})</span></h1>
+    <div class="standard_tile_line"></div>
+    <div class="standard_tile_padding">
+        <span class="help-hint">Click to edit the release details</span>
+        <br><br>
+        {if $game_releases}
+            <ul class="navigation-list">
+                {foreach from=$game_releases item=release}
+                    <li {if isset($release_id) and $release->getId() == $release_id}class="active"{/if}>
+                        <a href="games_release_detail.php?release_id={$release->getId()}">
+                            {if $release->getDate()}
+                                {$release->getDate()|date_format:"%Y"}
+                            {else}
+                                [unknown date]
+                            {/if}
+                            {if $release->getName() != null} <small> as "{$release->getName()}"</small>{/if}
+                        </a>
+
+                        <a title="Delete release"
+                            href="db_games_detail.php?action=delete_release&amp;game_id={$game->getId()}&amp;game_release_id[]={$release->getId()}"
+                            onclick="javascript:return confirm('This release will be deleted');">
+                            <i class="fa fa-trash" aria-hidden="true"></i>
+                        </a>
+                    </li>
+                {/foreach}
+            </ul>
+        {/if}
+        <br>
+        <a class="primary_button" href="games_release_detail.php?game_id={$game->getId()}">
+            Add a new release
+        </a>
+    </div>
+</div>


### PR DESCRIPTION
- Added menu on the left to navigate between releases, and add & delete
releases
- Added random screenshot of the game on the top-left, with a link to
quickly navigate to the game

Also changed the game editor:
- Remove the "statistics" that were display twice. Instead use the
navigation button on the right-hand side to display how many facts /
screenshots / boxscans / etc. there is
- Make the links to navigate to facts / screenshots / boxscans/ etc.
work
- Remove screenshot on the left-hand side of the game editing box since
there's now a tile with a random one
- Attempt to make editing of the game basic info work by putting the
form back with a submit button