### PR TITLE
Adding a new individual

### DIFF
--- a/Website/AtariLegend/php/admin/individuals/db_individuals.php
+++ b/Website/AtariLegend/php/admin/individuals/db_individuals.php
@@ -226,6 +226,10 @@ if (isset($action) and $action == 'insert_ind') {
 
             $sdbquery = $mysqli->query("INSERT INTO individual_text (ind_id, ind_profile) VALUES ($id, '$textfield')") or die("Couldn't insert into individual_text");
         }
+        else
+        {
+            $sdbquery = $mysqli->query("INSERT INTO individual_text (ind_id, ind_profile) VALUES ($id, ' ')") or die("Couldn't insert into individual_text");
+        }
 
         create_log_entry('Individuals', $id, 'Individual', $id, 'Insert', $_SESSION['user_id']);
 


### PR DESCRIPTION
When adding a new individual without a description, the individual text table is not inserted. When adding a screenshot, this would not work. This problem should now be fixed. I encountered this while adding Tord Jansson in our DB.