### PR TITLE
Force browsing via HTTPS

### DIFF
--- a/Website/AtariLegend/.htaccess
+++ b/Website/AtariLegend/.htaccess
@@ -20,6 +20,11 @@ ErrorDocument 404 /themes/templates/1/page_not_found.html
 RewriteEngine On
 RewriteBase /
 
+# Send all traffic to HTTPS, except when serving on localhost for development
+RewriteCond "%{HTTPS}" "off"
+RewriteCond "%{SERVER_NAME}" !localhost
+RewriteRule (.*) https://%{SERVER_NAME}/$1 [R=301,L]
+
 # Rewrite old interviews URLs to the new structure, as multiple websites are
 # still linking to the old URLs. e.g.:
 # /interviews/interview.php?interview_id=4 -> /interviews/interviews_detail.php?selected_interview_id=4


### PR DESCRIPTION
I have enabled SSL on the 1and1 control panel, so force users to use
HTTPS rather than HTTP. Benefits:
- Secure connection, especially when logging in to prevent passwords
from being snooped in
- HTTP-only sites will be marked with a red flag by future versions of
browsers: https://www.theverge.com/2018/2/8/16991254/chrome-not-secure-marked-http-encryption-ssl
- Should give us a bump in ranking on Google