### PR TITLE
Fix redirect for sections under construction

### DIFF
--- a/Website/AtariLegend/php/main/front/front.php
+++ b/Website/AtariLegend/php/main/front/front.php
@@ -59,8 +59,12 @@ if (isset($action) and $action == 'new_pwd') {
 
 if (isset($action) and $action == 'construction') {
     $_SESSION['edit_message'] = 'This section will be available soon - currently under construction';
-    header('Location: ' . $_SERVER['HTTP_REFERER']);
-    die('');
+    if (isset($_SERVER['HTTP_REFERER'])) {
+        header('Location: ' . $_SERVER['HTTP_REFERER']);
+    } else {
+        header('Location: /');
+    }
+    die();
 }
 
 //We are using this var to have the frontpage animation happen only once we visit AL


### PR DESCRIPTION
The Referer may not be available at all times resulting in an error that
was reported by the Google Search Console. If no Referer is available,
redirect to the home page.