### PR TITLE
Fixes #308: Only enable HTTPS redirect on the atarilegend.com domain

### DIFF
--- a/Website/AtariLegend/.htaccess
+++ b/Website/AtariLegend/.htaccess
@@ -22,7 +22,7 @@ RewriteBase /
 
 # Send all traffic to HTTPS, except when serving on localhost for development
 RewriteCond "%{HTTPS}" "off"
-RewriteCond "%{SERVER_NAME}" !localhost
+RewriteCond "%{SERVER_NAME}" (www\.)?atarilegend\.com
 RewriteRule (.*) https://%{SERVER_NAME}/$1 [R=301,L]
 
 # Rewrite old interviews URLs to the new structure, as multiple websites are


### PR DESCRIPTION
The previous configuration wouldn't work with the dev server that
resides on a different domain (dev.stonish.net). Only enable HTTPS
redirect on the main domain and ignore everything else (dev server,
localhost, etc.)