### PR TITLE
Fixes #514: Fix issue when users delete their own accounts

### DIFF
--- a/Website/AtariLegend/php/admin/user/db_user.php
+++ b/Website/AtariLegend/php/admin/user/db_user.php
@@ -342,6 +342,14 @@ if (isset($action) and $action == 'delete_user') {
                             $mysqli->query("DELETE from users WHERE user_id='$user_id_selected'") or die('deleting user failed');
 
                             $_SESSION['edit_message'] = 'User deleted succesfully';
+
+                            if ($user_id_selected == $_SESSION['user_id']) {
+                                // If the user deleted themselves, log them out
+                                $_SESSION = array();
+                                header("Location: /");
+                                mysqli_close($mysqli);
+                                die();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
It went into an infinite loop because it was trying to redirect to the
user edit page but the user didn't exist anymore, and so is not
logged-in causing issues with the permission check.

When a user delete their own account, redirect them to the home page.