### PR TITLE
Refactor News code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,7 +141,8 @@ module.exports = function (grunt) {
                 src: [
                     '<%= webRoot %>php/common/DAO/**/*.php',
                     '<%= webRoot %>php/common/Model/**/*.php',
-                    '<%= webRoot %>php/lib/Db.php'
+                    '<%= webRoot %>php/lib/Db.php',
+                    '<%= webRoot %>php/admin/news/**/*.php'
                 ]
             },
             all: {

--- a/Website/AtariLegend/php/admin/news/ajax_news_approve.php
+++ b/Website/AtariLegend/php/admin/news/ajax_news_approve.php
@@ -19,16 +19,16 @@ $commentsDao = new AL\Common\DAO\NewsDAO($mysqli);
 //********************************************************************************************
 // Get all the needed data to load the submission page!
 //********************************************************************************************
-if (isset($user_id)){
+if (isset($user_id)) {
     $smarty->assign(
         'news_submissions',
         $NewsSubmissionDAO->getAllSubmissionsForUser(isset($user_id) ? $user_id : null)
     );
-}else{   
+} else {
     $smarty->assign(
         'news_submissions',
         $NewsSubmissionDAO->getAllSubmissions(isset($user_id) ? $user_id : null)
-    ); 
+    );
 }
 
 $smarty->assign("nr_submissions", $NewsSubmissionDAO->getSubmissionCount());

--- a/Website/AtariLegend/php/admin/news/ajax_news_approve_edit.php
+++ b/Website/AtariLegend/php/admin/news/ajax_news_approve_edit.php
@@ -25,7 +25,8 @@ if (isset($action) and $action == "get_newsapprove_text") {
 }
 
 //Get the authors for the news post
-$sql_author = $mysqli->query("SELECT user_id,userid FROM users ORDER BY userid ASC") or die("Database error - getting members name");
+$sql_author = $mysqli->query("SELECT user_id,userid FROM users ORDER BY userid ASC")
+    or die("Database error - getting members name");
 
 while ($authors = $sql_author->fetch_array(MYSQLI_BOTH)) {
     $smarty->append('authors', array(

--- a/Website/AtariLegend/php/admin/news/ajax_news_edit.php
+++ b/Website/AtariLegend/php/admin/news/ajax_news_edit.php
@@ -21,18 +21,14 @@ $NewsDAO = new AL\Common\DAO\NewsDAO($mysqli);
 //********************************************************************************************
 $smarty->assign(
     'news',
-    $NewsDAO->getLatestNews(isset($user_id) ? $user_id : null, isset($last_timestamp) ? $last_timestamp : null, isset($action) ? $action : null, isset($news_search) ? $news_search : null)
-); 
-
-$smarty->assign("nr_news", $NewsDAO->getNewsCount());
-
-//if (isset($view) and $view == "users_news") {
-//    $smarty->assign("view", 'users_news');
-//}
-
-//if (isset($action) and $action == "autoload") {
-//    $smarty->assign("action", 'autoload_save');
-//}
+    $NewsDAO->getLatestNews(
+        5,
+        isset($user_id) ? $user_id : null,
+        isset($last_timestamp) ? $last_timestamp : null,
+        isset($action) ? $action : null,
+        isset($news_text) ? $news_text : null
+    )
+);
 
 //Send all smarty variables to the templates
 $smarty->display("file:" . $cpanel_template_folder . "ajax_news_edit.html");

--- a/Website/AtariLegend/php/admin/news/ajax_news_post_edit.php
+++ b/Website/AtariLegend/php/admin/news/ajax_news_post_edit.php
@@ -16,25 +16,20 @@ include("../../config/common.php");
 include("../../config/admin.php");
 require_once __DIR__."/../../lib/Db.php";
 require_once __DIR__."/../../common/DAO/NewsDAO.php";
+require_once __DIR__."/../../common/DAO/UserDAO.php";
 
 $newsDAO = new AL\Common\DAO\NewsDAO($mysqli);
+$userDAO = new AL\Common\DAO\UserDAO($mysqli);
 
 if (isset($action) and $action == "get_newspost_text") {
     if (isset($news_id)) {
-        $smarty->assign('news_item', $newsDAO->getSpecificNews($news_id, null));
+        $smarty->assign('article', $newsDAO->getNews($news_id));
         $smarty->assign('action', $action);
         $smarty->assign('news_id', $news_id);
     }
 }
 //Get the authors for the news post
-$sql_author = $mysqli->query("SELECT user_id,userid FROM users ORDER BY userid ASC") or die("Database error - getting members name");
-
-while ($authors = $sql_author->fetch_array(MYSQLI_BOTH)) {
-    $smarty->append('authors', array(
-        'user_id' => $authors['user_id'],
-        'user_name' => $authors['userid']
-    ));
-}
+$smarty->assign("users", $userDAO->getAllUsers());
 
 //Get the news images
 $sql_newsimage = $mysqli->query("SELECT news_image_id,news_image_name FROM news_image ORDER BY news_image_name");

--- a/Website/AtariLegend/php/admin/news/ajax_news_search.php
+++ b/Website/AtariLegend/php/admin/news/ajax_news_search.php
@@ -9,7 +9,7 @@
  *   Id: ajax_news_search.php 10/04/2018 ST Graveyard - creation of file
  *
  ***************************************************************************/
- 
+
  //load all common functions
 include("../../config/common.php");
 include("../../config/admin.php");
@@ -17,7 +17,7 @@ include("../../config/admin.php");
 require_once __DIR__."/../../lib/Db.php";
 require_once __DIR__."/../../common/DAO/NewsDAO.php";
 
-$NewsDAO = new AL\Common\DAO\NewsDAO($mysqli);
+$newsDAO = new AL\Common\DAO\NewsDAO($mysqli);
 
 //********************************************************************************************
 // Get all the needed data to load the news page!
@@ -26,28 +26,19 @@ $date = date_to_timestamp($news_searchYear, $news_searchMonth, $news_searchDay);
 
 $smarty->assign(
     'news',
-    $NewsDAO->getLatestNews(isset($author_search) ? $author_search : null, isset($date) ? $date : null, isset($action) ? $action : null, isset($newssearch) ? $newssearch : null)
-); 
-
-/*$smarty->assign(
-    'news',
-    $NewsSearchDAO->getSearchNews(isset($author_search) ? $author_search : null, isset($date) ? $date : null, isset($newssearch) ? $newssearch : null)
-); */
-
-$smarty->assign("nr_news", $NewsDAO->getSearchNewsCount(isset($author_search) ? $author_search : null, isset($date) ? $date : null, isset($newssearch) ? $newssearch : null));
+    $newsDAO->getLatestNews(
+        -1,
+        isset($author_search) ? $author_search : null,
+        isset($date) ? $date : null,
+        isset($newssearch) ? $newssearch : null
+    )
+);
 
 $smarty->assign("user_id", $author_search);
 $smarty->assign("news_search", $newssearch);
-
-//Search parameters for HTML
-//$smarty->assign("search_action", 'news_search');
-//$smarty->assign("search_author_id", '$author_search');
-//$smarty->assign("search_date", '$date');
-//$smarty->assign("search_string", '$newssearch');
 
 //Send all smarty variables to the templates
 $smarty->display("file:" . $cpanel_template_folder . "ajax_news_search.html");
 
 //close the connection
 mysqli_close($mysqli);
-

--- a/Website/AtariLegend/php/admin/news/news_add.php
+++ b/Website/AtariLegend/php/admin/news/news_add.php
@@ -33,7 +33,8 @@ while ($newsimages = $sql_newsimage->fetch_array(MYSQLI_BOTH)) {
 }
 
 //Get the authors for the news post
-$sql_author = $mysqli->query("SELECT user_id,userid FROM users ORDER BY userid ASC") or die("Database error - getting members name");
+$sql_author = $mysqli->query("SELECT user_id,userid FROM users ORDER BY userid ASC")
+    or die("Database error - getting members name");
 
 while ($authors = $sql_author->fetch_array(MYSQLI_BOTH)) {
     $smarty->append('authors', array(

--- a/Website/AtariLegend/php/admin/news/news_approve.php
+++ b/Website/AtariLegend/php/admin/news/news_approve.php
@@ -34,16 +34,16 @@ $NewsSubmissionDAO = new AL\Common\DAO\NewsSubmissionDAO($mysqli);
 //********************************************************************************************
 // Get all the needed data to load the submission page!
 //********************************************************************************************
-if (isset($user_id)){
+if (isset($user_id)) {
     $smarty->assign(
         'news_submissions',
         $NewsSubmissionDAO->getAllSubmissionsForUser(isset($user_id) ? $user_id : null)
     );
-}else{   
+} else {
     $smarty->assign(
         'news_submissions',
         $NewsSubmissionDAO->getAllSubmissions(isset($user_id) ? $user_id : null)
-    ); 
+    );
 }
 
 $smarty->assign("nr_submissions", $NewsSubmissionDAO->getSubmissionCount());

--- a/Website/AtariLegend/php/admin/news/news_edit.php
+++ b/Website/AtariLegend/php/admin/news/news_edit.php
@@ -27,19 +27,22 @@ require_once __DIR__."/../../common/DAO/NewsDAO.php";
 include("../../admin/games/quick_search_games.php");
 include("../../admin/news/quick_search_news.php");
 
-$NewsDAO = new AL\Common\DAO\NewsDAO($mysqli);
+$newsDAO = new AL\Common\DAO\NewsDAO($mysqli);
 
 //********************************************************************************************
 // Get all the needed data to load the news page!
 //********************************************************************************************
 $smarty->assign(
     'news',
-    $NewsDAO->getLatestNews(isset($user_id) ? $user_id : null, isset($last_timestamp) ? $last_timestamp : null, isset($action) ? $action : null, isset($news_text) ? $news_text : null)
-); 
+    $newsDAO->getLatestNews(
+        5,
+        isset($user_id) ? $user_id : null,
+        isset($last_timestamp) ? $last_timestamp : null,
+        isset($news_text) ? $news_text : null
+    )
+);
 
-$smarty->assign("nr_news", $NewsDAO->getNewsCount());
-
-//$smarty->assign("user_id", $_SESSION['user_id']);
+$smarty->assign('nr_news', $newsDAO->getNewsCount());
 
 //Send all smarty variables to the templates
 $smarty->display("file:" . $cpanel_template_folder . "news_edit.html");

--- a/Website/AtariLegend/php/admin/news/news_edit_images.php
+++ b/Website/AtariLegend/php/admin/news/news_edit_images.php
@@ -34,7 +34,8 @@ while ($news_images = $sql_images->fetch_array(MYSQLI_BOTH)) {
     $v_image .= $news_images['news_image_ext'];
 
     // Count how many times the image is used.
-    $query      = $mysqli->query("SELECT COUNT(*) AS count FROM news WHERE news_image_id = $news_images[news_image_id]");
+    $query      = $mysqli->query("SELECT COUNT(*) AS count"
+        ." FROM news WHERE news_image_id = $news_images[news_image_id]");
     $imagecount = $query->fetch_array(MYSQLI_BOTH);
 
     $smarty->append('news_images', array(

--- a/Website/AtariLegend/php/common/DAO/InterviewDAO.php
+++ b/Website/AtariLegend/php/common/DAO/InterviewDAO.php
@@ -17,7 +17,7 @@ class InterviewDAO {
     /**
      * Return the latest interviews, sorted by descending date
      *
-     * @param integer $limit How many interviewsto return
+     * @param integer $limit How many interviews to return
      * @return \AL\Common\Model\Interview\Interview[] An array of interviews
      */
     public function getLatestInterviews($limit = 20) {

--- a/Website/AtariLegend/php/common/DAO/NewsDAO.php
+++ b/Website/AtariLegend/php/common/DAO/NewsDAO.php
@@ -3,6 +3,7 @@ namespace AL\Common\DAO;
 
 require_once __DIR__."/../../lib/Db.php" ;
 require_once __DIR__."/../Model/News/News.php" ;
+require_once __DIR__."/../Model/User/User.php" ;
 
 /**
  * DAO for News
@@ -13,99 +14,50 @@ class NewsDAO {
     public function __construct($mysqli) {
         $this->mysqli = $mysqli;
     }
-    
-    private function getNewsQuery($user_id = null, $last_timestamp = null, $action = null, $news_text = null) {
-            
-        $query =  "SELECT
+
+    private function getLatestNewsQuery($user_id = null, $last_timestamp = null, $words = null) {
+        $query = "SELECT
                 news.news_id,
                 news.news_headline,
                 news.news_text,
-                news.news_date as date,
-                news.news_date as timestamp,
+                news.news_date,
+                news.user_id,
+                CONCAT(news_image.news_image_id, '.', news_image.news_image_ext) as news_image,
                 news_image.news_image_id,
-                CONCAT(news_image.news_image_id, \".\", news_image.news_image_ext) as news_image,
                 users.user_id,
                 users.userid,
                 users.email,
                 users.join_date,
                 users.karma,
                 users.avatar_ext,
-                (SELECT COUNT(*) 
-                        FROM news 
-                            WHERE news.user_id = users.user_id) AS user_news_count
-            FROM
-                news ";
+                (SELECT COUNT(*)
+                    FROM news
+                    WHERE news.user_id = users.user_id) AS user_news_count
+            FROM news
+            LEFT JOIN news_image ON news.news_image_id = news_image.news_image_id
+            LEFT JOIN users ON news.user_id = users.user_id";
 
-        if (isset($action) and $action =='search') {
-            $query .= "LEFT JOIN news_search_wordmatch ON
-                        (news_search_wordmatch.news_id = news.news_id)
-                      LEFT JOIN news_search_wordlist ON
-                        (news_search_wordlist.news_word_id = news_search_wordmatch.news_word_id) ";
+        if ($words != null) {
+            $query .= " LEFT JOIN news_search_wordmatch
+                    ON news_search_wordmatch.news_id = news.news_id
+                LEFT JOIN news_search_wordlist
+                    ON news_search_wordlist.news_word_id = news_search_wordmatch.news_word_id";
         }
 
-        $query .= "LEFT JOIN news_image ON
-                (news.news_image_id = news_image.news_image_id)
-            LEFT JOIN users ON
-                (news.user_id = users.user_id)";
-
-        if (isset($user_id) and ( $user_id <> '-' and $user_id <> '' )) {
-            $query .= " WHERE news.user_id = $user_id";
+        $constraints = [];
+        if ($user_id != null) {
+            $constraints[] = "news.user_id = ?";
+        }
+        if ($last_timestamp != null) {
+            $constraints[] = "news.news_date <= ?";
+        }
+        if ($words != null) {
+            $constraints[] = "news_search_wordlist.news_word_text LIKE ?";
         }
 
-        if (isset($user_id) and ( $user_id <> '-' and $user_id <> '' )) {
-            if (isset($action)) {
-                if ($action=="search") {
-                    if (isset($news_text) and $news_text != '') {
-                        $query .= " AND news_search_wordlist.news_word_text LIKE '$news_text'";
-                    } else {
-                        //$query .= " AND news_search_wordlist.news_word_text LIKE '%'";
-                    }
-                    $query .= " AND news.news_date <= $last_timestamp ";
-                } else {
-                    $query .= " AND news.news_date < $last_timestamp ";
-                }
-            }
-        } else {
-            if (isset($action)) {
-                if ($action=="search") {
-                    $query .= " WHERE news.news_date <= $last_timestamp ";
-                    if (isset($news_text) and $news_text != '') {
-                        $query .= " AND news_search_wordlist.news_word_text LIKE '$news_text'";
-                    } else {
-                        //$query .= " AND news_search_wordlist.news_word_text LIKE '%'";
-                    }
-                } else {
-                    $query .= " WHERE news.news_date < $last_timestamp ";
-                }
-            }
-        }
+        $query .= \AL\Db\assemble_constraints($constraints);
 
-        $query .= " GROUP BY news.news_id ORDER BY news_date DESC LIMIT 5";
-        return $query;
-    }
-
-    private function getNewsSearchCountQuery($user_id = null, $date = null, $text = null) {
- 
-        $query =  "SELECT count(DISTINCT news.news_id)
-            FROM
-                news
-            LEFT JOIN news_search_wordmatch ON (news_search_wordmatch.news_id = news.news_id) 
-            LEFT JOIN news_search_wordlist ON (news_search_wordlist.news_word_id = news_search_wordmatch.news_word_id) 
-            LEFT JOIN news_image ON
-                (news.news_image_id = news_image.news_image_id)
-            LEFT JOIN users ON
-                (news.user_id = users.user_id)";
-
-        $query .= " WHERE news.news_date <= $date";
-
-        if (isset($text) and $text != '') {
-            $query .= " AND news_search_wordlist.news_word_text LIKE '$text'";
-        } else {
-        }
-
-        if (isset($user_id) and $user_id != '-') {
-            $query .= " AND news.user_id = $user_id";
-        }
+        $query .= " ORDER BY news_date DESC LIMIT ?";
 
         return $query;
     }
@@ -114,14 +66,36 @@ class NewsDAO {
      * Return the latest news, sorted by descending date
      *
      * @param integer $limit How many news to return
+     * @param integer $user_id To retrieve the news of a specific user only
+     * @param integer $user_id To retrieve only the news before a given timestamp
      * @return \AL\Common\Model\News\News[] An array of news
      */
-    public function getLatestNews($user_id = null, $last_timestamp = null, $action = null, $view = null) {
+    public function getLatestNews($limit = 20, $user_id = null, $last_timestamp = null, $words = null) {
+        $query = $this->getLatestNewsQuery($user_id, $last_timestamp, $words);
+        $bind_string = "";
+        $bind_params = array();
+
+        if ($user_id != null) {
+            $bind_string .= "i";
+            $bind_params[] = $user_id;
+        }
+        if ($last_timestamp != null) {
+            $bind_string .= "i";
+            $bind_params[] = $last_timestamp;
+        }
+        if ($words != null) {
+            $bind_string .= "s";
+            $bind_params[] = $words;
+        }
+
+        $bind_string .= "i";
+        $bind_params[] = $limit;
+
         $stmt = \AL\Db\execute_query(
             "NewsDAO: getLatestNews",
             $this->mysqli,
-            $this->getNewsQuery($user_id, $last_timestamp, $action, $view),
-            null, null
+            $query,
+            $bind_string, ...$bind_params
         );
 
         \AL\Db\bind_result(
@@ -130,41 +104,39 @@ class NewsDAO {
             $id,
             $headline,
             $text,
-            $timestamp,
             $date,
-            $image_id,
-            $image,
             $userid,
-            $username,
-            $email,
-            $join_date,
-            $karma,
-            $avatar_ext,
+            $image,
+            $image_id,
+            $user_id,
+            $user_userid,
+            $user_email,
+            $user_join_date,
+            $user_karma,
+            $user_avatar_ext,
             $user_news_count
         );
 
         $news = [];
         while ($stmt->fetch()) {
-            $text = nl2br($text);
-            $text = InsertALCode($text);
-            $text = trim($text);
-            $text = RemoveSmillies($text);
-            
+            $user = new \AL\Common\Model\User\User(
+                $user_id,
+                $user_userid,
+                $user_email,
+                $user_join_date,
+                $user_karma,
+                $user_avatar_ext,
+                $user_news_count
+            );
+
             $news[] = new \AL\Common\Model\News\News(
                 $id,
                 $headline,
                 $text,
-                $timestamp,
                 $date,
-                $image_id,
                 $image,
-                $userid,
-                $username,
-                $email,
-                $join_date,
-                $karma,
-                $avatar_ext,
-                $user_news_count
+                $image_id,
+                $user
             );
         }
 
@@ -172,188 +144,80 @@ class NewsDAO {
 
         return $news;
     }
-    
-    
+
     /**
-    * Return all news posts, sorted by descending date
-    * @return \AL\Common\Model\News\News[] An array of news
+    * Return a specific news article
+
+    * @return \AL\Common\Model\News\News A single news
     */
- /**   public function getAllNewsForUser($user_id = null, $last_timestamp = null, $action = null, $view = null) {
-         $stmt = \AL\Db\execute_query(
-            "NewsDAO: getAllNewsForUser",
-            $this->mysqli,
-            $this->getNewsQuery($user_id, $last_timestamp, $action, $view),
-            null, null
-        );
-
-        \AL\Db\bind_result(
-            "NewsDAO: getLatestNews",
-            $stmt,
-            $id,
-            $headline,
-            $text,
-            $timestamp,
-            $date,
-            $image_id,
-            $image,
-            $userid,
-            $username,
-            $email,
-            $join_date,
-            $karma,
-            $avatar_ext,
-            $user_news_count
-        );
-
-        $news = [];
-        while ($stmt->fetch()) {
-            $text = nl2br($text);
-            $text = InsertALCode($text);
-            $text = trim($text);
-            $text = RemoveSmillies($text);
-
-            $news[] = new \AL\Common\Model\News\News(
-                $id,
-                $headline,
-                $text,
-                $timestamp,
-                $date,
-                $image_id,
-                $image,
-                $userid,
-                $username,
-                $email,
-                $join_date,
-                $karma,
-                $avatar_ext,
-                $user_news_count
-            );
-        }
-
-        $stmt->close();
-
-        return $news;
-    }
-**/
-     /**
-    * Get the total count of news on the website
-    *
-    * @param  integer $user_id Optional ID of a user to count comments for
-    * @return integer Number of comments     */
-    public function getNewsCount($user_id = null) {
-        if (isset($user_id)) {
-            $stmt = \AL\Db\execute_query(
-                "NewsDAO: Get news count for user_id $user_id",
-                $this->mysqli,
-                "SELECT COUNT(*) FROM news WHERE user_id = ?",
-                "i",
-                $user_id
-            );
-        } else {
-            $stmt = \AL\Db\execute_query(
-                "NewsDAO: Get news count in database",
-                $this->mysqli,
-                "SELECT COUNT(*) FROM news",
-                null,
-                null
-            );
-        }
-
-        \AL\Db\bind_result(
-            "NewsDAO: Get news count",
-            $stmt,
-            $count
-        );
-
-        $stmt->fetch();
-        $stmt->close();
-
-        return $count;
-    }
-    
-        /**
-    * Return a specific news submissions
-    * @return \AL\Common\Model\News\News[] An array of news
-    */
-    public function getSpecificNews($news_id, $action) {
+    public function getNews($news_id) {
         $stmt = \AL\Db\execute_query(
-            "NewsDAO: getSpecificSubmissions",
+            "NewsDAO: getNews",
             $this->mysqli,
             "SELECT
-            news.news_id,
-            news.news_headline,
-            news.news_text,
-            news.news_date as date,
-            news.news_date as timestamp,
-            news_image.news_image_id,
-            CONCAT(news_image.news_image_id, \".\", news_image.news_image_ext) as news_image,
-            users.user_id,
-            users.userid,
-            users.email,
-            users.join_date,
-            users.karma,
-            users.avatar_ext,
-            (SELECT COUNT(*) 
-                    FROM news 
-                        WHERE news.user_id = users.user_id) AS user_news_count
-            FROM
-                news
-            LEFT JOIN news_image ON
-                (news.news_image_id = news_image.news_image_id)
-            LEFT JOIN users ON
-                (news.user_id = users.user_id)
+                news.news_id,
+                news.news_headline,
+                news.news_text,
+                news.news_date,
+                news.user_id,
+                CONCAT(news_image.news_image_id, '.', news_image.news_image_ext) as news_image,
+                news_image.news_image_id,
+                users.user_id,
+                users.userid,
+                users.email,
+                users.join_date,
+                users.karma,
+                users.avatar_ext,
+                (SELECT COUNT(*)
+                    FROM news
+                    WHERE news.user_id = users.user_id) AS user_news_count
+            FROM news
+            LEFT JOIN news_image ON news.news_image_id = news_image.news_image_id
+            LEFT JOIN users ON news.user_id = users.user_id
             WHERE news.news_id = ?",
-            "i",
-            $news_id
+            "i", $news_id
         );
 
         \AL\Db\bind_result(
-            "NewsDAO: get specific News post",
+            "NewsDAO: getNews",
             $stmt,
             $id,
             $headline,
             $text,
-            $timestamp,
             $date,
-            $image_id,
-            $image,
             $userid,
-            $username,
-            $email,
-            $join_date,
-            $karma,
-            $avatar_ext,
+            $image,
+            $image_id,
+            $user_id,
+            $user_userid,
+            $user_email,
+            $user_join_date,
+            $user_karma,
+            $user_avatar_ext,
             $user_news_count
         );
 
-        $news = [];
-        
-        while ($stmt->fetch()) {
-            if (isset($action) and $action == 'save_news_post_text') {
-                $text = nl2br($text);
-                $text = InsertALCode($text);
-                $text = trim($text);
-                $text = RemoveSmillies($text);
-            } else {
-                $breaks = array("<br />","<br>","<br/>");
-                $text = str_ireplace($breaks, "\r\n", $text);
-            }
-    
-            $news[] = new \AL\Common\Model\News\News(
+        $news = null;
+
+        if ($stmt->fetch()) {
+            $user = new \AL\Common\Model\User\User(
+                $user_id,
+                $user_userid,
+                $user_email,
+                $user_join_date,
+                $user_karma,
+                $user_avatar_ext,
+                $user_news_count
+            );
+
+            $news = new \AL\Common\Model\News\News(
                 $id,
                 $headline,
                 $text,
-                $timestamp,
                 $date,
-                $image_id,
                 $image,
-                $userid,
-                $username,
-                $email,
-                $join_date,
-                $karma,
-                $avatar_ext,
-                $user_news_count
+                $image_id,
+                $user
             );
         }
 
@@ -361,17 +225,22 @@ class NewsDAO {
 
         return $news;
     }
-    
-    public function getSearchNewsCount($user_id = null, $date = null, $text = null) {
+
+    /**
+    * Get the total count of news on the website
+    * @return number Total number of news
+    */
+    public function getNewsCount() {
         $stmt = \AL\Db\execute_query(
-            "NewsSearchDAO: getSearchNewsCount",
+            "NewsDAO: getNewsCount",
             $this->mysqli,
-            $this->getNewsSearchCountQuery($user_id, $date, $text),
-            null, null
+            "SELECT COUNT(*) FROM news",
+            null,
+            null
         );
 
         \AL\Db\bind_result(
-            "NewsSearchDAO: getSearchNewsCount",
+            "NewsDAO: getNewsCount",
             $stmt,
             $count
         );

--- a/Website/AtariLegend/php/common/DAO/UserDAO.php
+++ b/Website/AtariLegend/php/common/DAO/UserDAO.php
@@ -1,0 +1,66 @@
+<?php
+namespace AL\Common\DAO;
+
+require_once __DIR__."/../../lib/Db.php" ;
+require_once __DIR__."/../Model/User/User.php" ;
+
+/**
+ * DAO for User
+ */
+class UserDAO {
+    private $mysqli;
+
+    public function __construct($mysqli) {
+        $this->mysqli = $mysqli;
+    }
+
+    /**
+     * Retrieve all users
+     * @return \AL\Common\Model\User\User[] A list of users
+     */
+    public function getAllUsers() {
+        $stmt = \AL\Db\execute_query(
+            "UserDAO: getAllUsers",
+            $this->mysqli,
+            "SELECT
+                user_id,
+                userid,
+                email,
+                join_date,
+                karma,
+                avatar_ext
+            FROM users
+            ORDER BY userid ASC",
+            null, null
+        );
+
+        \AL\Db\bind_result(
+            "UserDAO: getAllUsers",
+            $stmt,
+            $id,
+            $userid,
+            $email,
+            $join_date,
+            $karma,
+            $avatar_ext
+        );
+
+        $users = [];
+
+        while ($stmt->fetch()) {
+            $users[] = new \AL\Common\Model\User\User(
+                $id,
+                $userid,
+                $email,
+                $join_date,
+                $karma,
+                $avatar_ext,
+                0
+            );
+        }
+
+        $stmt->close();
+
+        return $users;
+    }
+}

--- a/Website/AtariLegend/php/common/Model/News/News.php
+++ b/Website/AtariLegend/php/common/Model/News/News.php
@@ -11,70 +11,34 @@ class News {
     private $id;
     private $headline;
     private $text;
-    private $timestamp;
     private $date;
-    private $image_id;
     private $image;
+    private $image_id;
     private $userid;
-    private $username;
-    private $email;
-    private $join_date;
-    private $karma;
-    private $avatar_ext;
-    private $user_news_count;
 
     public function __construct(
         $id,
         $headline,
         $text,
-        $timestamp,
         $date,
-        $image_id,
         $image,
-        $userid,
-        $username,
-        $email,
-        $join_date,
-        $karma,
-        $avatar_ext,
-        $user_news_count
+        $image_id,
+        $user
     ) {
         $this->id = $id;
         $this->headline = $headline;
         $this->text = $text;
-        $this->timestamp = $timestamp;
-        $this->post_date = date("F j, Y", $date);
+        $this->date = $date;
+        $this->user = $user;
         $this->image_id = $image_id;
-        $this->userid = $userid;
-        $this->username = $username;
-        $this->email = $email;
-        
-        if ($join_date == "") {
-            $this->join = "unknown";
-        } else {
-            $this->join = date("d-m-y", $join_date);
-        }
-       
-        $this->karma = $karma;
-        $this->user_news_count = $user_news_count;
-        
-        if ($avatar_ext && $avatar_ext !== "") {
-            $this->avatar_image = $GLOBALS['user_avatar_path']."/${userid}.${avatar_ext}";
-        } else {
-            $this->avatar_image = $GLOBALS['style_folder']."/images/default_avatar_image.png";
-        }
 
-        if ($image) {
-            $this->image = $GLOBALS['news_images_path']."/${image}";
+        if ($image != null) {
+            $this->image = $GLOBALS['news_images_path'].$image;
         }
     }
 
     public function getId() {
         return $this->id;
-    }
-    
-    public function getImageId() {
-        return $this->image_id;
     }
 
     public function getHeadline() {
@@ -84,45 +48,21 @@ class News {
     public function getText() {
         return $this->text;
     }
-    
-    public function getTimestamp() {
-        return $this->timestamp;
-    }
 
     public function getDate() {
-        return $this->post_date;
+        return $this->date;
     }
 
     public function getImage() {
         return $this->image;
     }
 
-    public function getUserId() {
-        return $this->userid;
-    }
-    
-    public function getUserName() {
-        return $this->username;
-    }
-    
-    public function getEmail() {
-        return $this->email;
+    public function getImageId() {
+        return $this->image_id;
     }
 
-    public function getJoinDate() {
-        return $this->join;
-    }
-
-    public function getKarma() {
-        return $this->karma;
-    }
-    
-    public function getAvatarImage() {
-        return $this->avatar_image;
-    }
-    
-    public function getUserNewsCount() {
-        return $this->user_news_count;
+    public function getUser() {
+        return $this->user;
     }
 
     /**

--- a/Website/AtariLegend/php/common/Model/User/User.php
+++ b/Website/AtariLegend/php/common/Model/User/User.php
@@ -1,0 +1,68 @@
+<?php
+namespace AL\Common\Model\User;
+
+require_once __DIR__."/../../../config/config.php";
+require_once __DIR__."/../../../lib/functions.php";
+
+/**
+ * Maps to the `user` table
+ */
+class User {
+    private $id;
+    private $name;
+    private $email;
+    private $join_date;
+    private $karma;
+    private $avatar;
+    private $news_count;
+
+    public function __construct(
+        $id,
+        $name,
+        $email,
+        $join_date,
+        $karma,
+        $avatar_ext,
+        $news_count
+    ) {
+        $this->id = $id;
+        $this->name = $name;
+        $this->email = $email;
+        $this->join_date = $join_date;
+        $this->karma = $karma;
+
+        if ($avatar_ext != null && $avatar_ext != '') {
+            $this->avatar = $GLOBALS['user_avatar_path'].$id.'.'.$avatar_ext;
+        }
+
+        $this->news_count = $news_count;
+    }
+
+    public function getId() {
+        return $this->id;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+
+    public function getEmail() {
+        return $this->email;
+    }
+
+    public function getJoinDate() {
+        return $this->join_date;
+    }
+
+    public function getKarma() {
+        return $this->karma;
+    }
+
+    public function getAvatar() {
+        return $this->avatar;
+    }
+
+    public function getNewsCount() {
+        return $this->news_count;
+    }
+}

--- a/Website/AtariLegend/php/lib/Db.php
+++ b/Website/AtariLegend/php/lib/Db.php
@@ -59,3 +59,23 @@ function bind_result($context, $stmt, &...$params) {
     $stmt->bind_result(...$params)
         or die("Error binding results $err_ctx");
 }
+
+/**
+ * Assemble multiple constraints into a SQL string with the proper
+ * WHERE / AND syntax depending on the number of constraints
+ * @param $constraints A list of constraints, like "id = ?" or
+ *  "name LIKE ?".
+ * @return String A SQL string with constraints suitable
+ *  to use in a SQL query
+ */
+function assemble_constraints($constraints) {
+    $query = "";
+    if (count($constraints) > 1) {
+        $query .= " WHERE ".array_shift($constraints);
+        $query .= " AND ".join($constraints, " AND ");
+    } elseif (count($constraints) == 1) {
+        $query .= " WHERE ".array_shift($constraints);
+    }
+
+    return $query;
+}

--- a/Website/AtariLegend/php/main/front/atom.php
+++ b/Website/AtariLegend/php/main/front/atom.php
@@ -22,7 +22,7 @@ foreach ($news as $article) {
         "link" => REQUEST_SITEURL."/news/news.php",
         "id" => REQUEST_SITEURL."/news/news.php?id=".$article->getId(),
         "updated" => $article->getDate(),
-        "author" => $article->getUserName(),
+        "author" => $article->getUser()->getName(),
         "content" => $article->getHtmlText()
     );
 }

--- a/Website/AtariLegend/themes/templates/1/admin/ajax_news_edit.html
+++ b/Website/AtariLegend/themes/templates/1/admin/ajax_news_edit.html
@@ -11,106 +11,102 @@
 *}
 
 <div id="news_edit_list">
-{foreach from=$news item=line}
-    <div id="jsNewsId{$line->getId()}" class="infinite-item">
-        <div class="news_post_box" id="{$line->getTimestamp()}">
-            <div class="news_userinfo">
-                {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() != ''}
-                    <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                {else}
-                {/if}
-                <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getUserName()}</a>
-                <br><br><br>
-                <span class="text-nowrap">
-                    Joined: {$line->getJoinDate()}
-                    <br>
-                    {if $line->getUserNewsCount() > 0}
-                        News posts:  <a href="#" data-user-id="{$line->getUserId()}" class="standard_tile_link jsUserNewsLink">{$line->getUserNewsCount()}</a>
-                    {else}
-                        News posts:  {$line->getUserNewsCount()}
-                    {/if}
-                    <br>
-                    {if $line->getKarma() == '' OR $line->getKarma() == 0}
-                        Karma : 0
-                    {else}
-                        Karma: <a href="../user/user_statistics.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getKarma()}</a>
-                    {/if}
-                </span>
-            </div>
-            <div class="news_post_detail" id="jsNewsEditBox{$line->getId()}">
-                <div class="news_userinfo_phoneview">
-                    {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() !== ''}
-                        <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                    {else}
-                        <img src="../../includes/show_image.php?file={$style_dir} {$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                    {/if}
-                    <h6>
-                        <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a>
-                    </h6>
-                </div>
-                <h4 class="news_title">
-                    {$line->getHeadline()}</a>
-                </h4>
-                <ul class="news_buttons">
-                    {if $line->getEmail() !== ''}
-                    <li class="primary_button jsNewsEmailButton">
-                        <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                            <i class="fa fa-envelope" aria-hidden="true"></i>
-                        </a>
-                    </li>
-                    {/if}
-                    <li class="primary_button jsNewsPostEditButton" data-news-id="{$line->getId()}">
-                        <a class="links_addnew_link">
-                            <i class="fa fa-pencil" aria-hidden="true"></i>
-                        </a>
-                    </li>
-                    <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$line->getId()}">
-                        <a class="links_addnew_link">
-                            <i class="fa fa-trash" aria-hidden="true"></i>
-                        </a>
-                    </li>
-                    <div class="news_button_dropdown" data-dropdown-id="{$line->getId()}">
-                        <li class="primary_button">
-                            <a class="links_addnew_link">
-                                <i class="fa fa-bars" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        <div class="dropdown_box" id="dropdown_box{$line->getId()}">
-                            <li class="dropdown_item">
-                                <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                                    Email
-                                </a>
-                            </li>
-                            <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$line->getId()}">
-                                Edit
-                            </li>
-                            <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$line->getId()}">
-                                Delete
-                            </li>
+        {if count($news) > 0}
+            {foreach from=$news item=article}
+                <div id="jsNewsId{$article->getId()}" class="infinite-item">
+                    <div class="news_post_box" id="{$article->getDate()}">
+                        <div class="news_userinfo">
+                            {if $article->getUser()->getAvatar() != null}
+                                <img src="../../includes/show_image.php?file={$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
+                            {/if}
+                            <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}" class="standard_tile_link">{$article->getUser()->getName()}</a>
+                            <br><br><br>
+                            <span class="text-nowrap">
+                                Joined: {$article->getUser()->getJoinDate()|date_format:"d-m-y"|default:"n/a"}
+                                <br>
+                                News posts:  <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}" data-user-id="{$article->getUser()->getId()}" class="standard_tile_link jsUserNewsLink">{$article->getUser()->getNewsCount()}</a>
+                                <br>
+                                Karma: <a href="../user/user_statistics.php?user_id_selected={$article->getUser()->getId()}" class="standard_tile_link">{$article->getUser()->getKarma()}</a>
+                            </span>
+                        </div>
+                        <div class="news_post_detail" id="jsNewsEditBox{$article->getId()}">
+                            <div class="news_userinfo_phoneview">
+                                {if $article->getUser()->getAvatar() != null}
+                                    <img src="../../includes/show_image.php?file={$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
+                                {else}
+                                    <img src="../../includes/show_image.php?file={$style_dir} {$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
+                                {/if}
+                                <h6>
+                                    <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}">{$article->getUser()->getName()}</a>
+                                </h6>
+                            </div>
+                            <h4 class="news_title">
+                                {$article->getHeadline()}</a>
+                            </h4>
+                            <ul class="news_buttons">
+                                {if $article->getUser()->getEmail() !== ''}
+                                <li class="primary_button jsNewsEmailButton">
+                                    <a href="mailto:{$article->getUser()->getEmail()}?subject=Your news post : {$article->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
+                                        <i class="fa fa-envelope" aria-hidden="true"></i>
+                                    </a>
+                                </li>
+                                {/if}
+                                <li class="primary_button jsNewsPostEditButton" data-news-id="{$article->getId()}">
+                                    <a class="links_addnew_link">
+                                        <i class="fa fa-pencil" aria-hidden="true"></i>
+                                    </a>
+                                </li>
+                                <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$article->getId()}">
+                                    <a class="links_addnew_link">
+                                        <i class="fa fa-trash" aria-hidden="true"></i>
+                                    </a>
+                                </li>
+                                <div class="news_button_dropdown" data-dropdown-id="{$article->getId()}">
+                                    <li class="primary_button">
+                                        <a class="links_addnew_link">
+                                            <i class="fa fa-bars" aria-hidden="true"></i>
+                                        </a>
+                                    </li>
+                                    <div class="dropdown_box" id="dropdown_box{$article->getId()}">
+                                        <li class="dropdown_item">
+                                            <a href="mailto:{$article->getUser()->getEmail()}?subject=Your news post : {$article->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
+                                                Email
+                                            </a>
+                                        </li>
+                                        <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$article->getId()}">
+                                            Edit
+                                        </li>
+                                        <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$article->getId()}">
+                                            Delete
+                                        </li>
+                                    </div>
+                                </div>
+                            </ul>
+                            <div class="news_line" id="line_above_info"></div>
+                            <h4 class="news_title_phoneview">
+                                {$article->getHeadline()}</a>
+                            </h4>
+                            <div class="news_post_info">
+                                Posted <span>by <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}">{$article->getUser()->getName()}</a></span> on {$article->getDate()|date_format}
+                            </div>
+                            <div class="news_line" id="line_below_info"></div>
+                            <div class="news_post_text" id="jsNewsTextBox{$article->getId()}">
+                                {if $article->getImage() != null}
+                                    <div style="float:left;margin:15px;">
+                                        <img src="../../includes/show_image.php?file={$article->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
+                                    </div>
+                                {/if}
+                                <br>
+                                {$article->getHtmlText()}
+                                <br>
+                                <br>
+                            </div>
                         </div>
                     </div>
-                </ul>
-                <div class="news_line" id="line_above_info"></div>
-                <h4 class="news_title_phoneview">
-                    {$line->getHeadline()}</a>
-                </h4>
-                <div class="news_post_info">
-                    Posted <span>by <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a></span> on {$line->getDate()}
                 </div>
-                <div class="news_line" id="line_below_info"></div>
-                <div class="news_post_text" id="jsNewsTextBox{$line->getId()}">
-                    {if $line->getImageId() != ''}
-                        <div style="float:left;margin:15px;">
-                            <img src="../../includes/show_image.php?file={$line->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
-                        </div>
-                    {/if}
-                    <br>
-                    {$line->getText()}
-                    <br>
-                    <br>
-                </div>
-            </div>
-        </div>
+            {/foreach}
+        {else}
+            <div class="standard_tile_text_center">No news entries to approve.</div>
+        {/if}
     </div>
-{/foreach}
-</div>
+    <div id="JSnewsText" style="display:none;">{if isset($news_search)}{$news_search}{/if}</div>

--- a/Website/AtariLegend/themes/templates/1/admin/ajax_news_post_edit.html
+++ b/Website/AtariLegend/themes/templates/1/admin/ajax_news_post_edit.html
@@ -12,221 +12,107 @@
 
 {* START NEW NEWS BOX *}
 {if isset($action) and $action=="get_newspost_text"}
-    {foreach from=$news_item item=line}
-        <div class="news_userinfo_phoneview">
-            {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() !== ''}
-                <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
+    <div class="news_userinfo_phoneview">
+        {if $article->getUser()->getAvatar() != null}
+            <img src="../../includes/show_image.php?file={$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
+        {else}
+            <img src="../../includes/show_image.php?file={$style_dir} {$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
+        {/if}
+        <h6>
+            <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}">{$article->getUser()->getName()}</a>
+        </h6>
+    </div>
+    <input type="text" name="headline" id="JsHeadlineText" maxlength='64' class="standard_input input_75" required value="{$article->getHeadline()}">
+    <ul class="news_buttons">
+        <button class="primary_button jsNewsPostEditSaveButton news_save_button" data-news-id="{$article->getId()}" type="button">
+            <i class="fa fa-floppy-o" aria-hidden="true"></i>
+        </button>
+    </ul>
+    <br>
+    <select name="members"
+        id="member_select" class="standard_select select_large">
+        <option value="-">-</option>
+        {foreach from=$users item=$user}
+            <option
+                value="{$user->getId()}"
+                {if $user->getId() == $article->getUser()->getId()}selected{/if}>
+                {$user->getName()}
+            </option>
+        {/foreach}
+    </select>
+    <br>
+    <select name="news_image_id" class="standard_select select_large" id="news_images_select">
+        <option value="0">-</option>
+        {foreach from=$news_images item=image}
+            {if $article->getImageId() eq $image.image_id}
+                <option value="{$image.image_id}" selected>{$image.image_name}</option>
             {else}
-                <img src="../../includes/show_image.php?file={$style_dir} {$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
+                <option value="{$image.image_id}">{$image.image_name}</option>
             {/if}
-            <h6>
-                <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a>
-            </h6>
-        </div>
-        <input type="text" name="headline" id="JsHeadlineText" maxlength='64' class="standard_input input_75" required value="{$line->getHeadline()}">
-        <ul class="news_buttons">
-            <button class="primary_button jsNewsPostEditSaveButton news_save_button" data-news-id="{$news_id}" type="button">
-                <i class="fa fa-floppy-o" aria-hidden="true"></i>
-            </button>
-        </ul>
-        <br>
-        <select name="members"
-            id="member_select" class="standard_select select_large">
-            <option value="-">-</option>
-            {foreach from=$authors item=line_author}
-                {if $line_author.user_id == $line->getUserId()}
-                    <option value="{$line_author.user_id}" selected>{$line_author.user_name}</option>
-                {else}
-                    <option value="{$line_author.user_id}">{$line_author.user_name}</option>
-                {/if}
-            {/foreach}
-        </select>
-        <br>
-        <select name="news_image_id" class="standard_select select_large" id="news_images_select">
-            <option value="0">-</option>
-            {foreach from=$news_images item=line_images}
-                {if $line->getImageId() eq $line_images.image_id}
-                    <option value="{$line_images.image_id}" selected>{$line_images.image_name}</option>
-                {else}
-                    <option value="{$line_images.image_id}">{$line_images.image_name}</option>
-                {/if}
-            {/foreach}
-        </select>
-        <br>
-        {html_select_date all_id="{$news_id}" time=$line->getDate() start_year="2000" class="standard_select"}
-        <br>
-        <br>
-        <input type="button" class="primary_button" accesskey= "b" name="addbbcode0" value="B" onclick="bbstyle(0,'textfield{$news_id}')">
-        <input type="button" class="primary_button" accesskey= "u" name="addbbcode4" value="U" onclick="bbstyle(4,'textfield{$news_id}')">
-        <input type="button" class="primary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textfield{$news_id}')">
-        <input type="button" class="primary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield{$news_id}')">
-        <input type="button" class="primary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield{$news_id}')">
-        <input type="button" class="primary_button" accesskey="frontpage" name="addbbcode14" value="Frontpage" onClick="bbstyle(14,'textfield{$news_id}')">
-        <br>
-        <textarea class="primary_textarea" rows="4" name="textfield{$news_id}" id="jsNewsText" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$line->getText()}</textarea>
-    {/foreach}
-{/if}
-
-{if isset($action) and ( $action=='search_news_text' )}
-    {if $nr_news <> ''}<div class="standard_tile_text_center">There are currently {$nr_news} posts in the news table.</div><br>{/if}
-    {foreach from=$news item=line}
-        <div id="jsNewsId{$line->getId()}" class="infinite-item">
-            <div class="news_post_box" id="{$line->getTimestamp()}">
-                <div class="news_userinfo">
-                    {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() != ''}
-                        <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                    {else}
-                    {/if}
-                    <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getUserName()}</a>
-                    <br><br><br>
-                    <span class="text-nowrap">
-                        Joined: {$line->getJoinDate()}
-                        <br>
-                        {if $line->getUserNewsCount() > 0}
-                            News posts:  <a href="#" data-user-id="{$line->getUserId()}" class="standard_tile_link jsUserNewsLink">{$line->getUserNewsCount()}</a>
-                        {else}
-                            News posts:  {$line->getUserNewsCount()}
-                        {/if}
-                        <br>
-                        {if $line->getKarma() == '' OR $line->getKarma() == 0}
-                            Karma : 0
-                        {else}
-                            Karma: <a href="../user/user_statistics.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getKarma()}</a>
-                        {/if}
-                    </span>
-                </div>
-                <div class="news_post_detail" id="jsNewsEditBox{$line->getId()}">
-                    <div class="news_userinfo_phoneview">
-                        {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() !== ''}
-                            <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                        {else}
-                            <img src="../../includes/show_image.php?file={$style_dir} {$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                        {/if}
-                        <h6>
-                            <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a>
-                        </h6>
-                    </div>
-                    <h4 class="news_title">
-                        {$line->getHeadline()}</a>
-                    </h4>
-                    <ul class="news_buttons">
-                        {if $line->getEmail() !== ''}
-                        <li class="primary_button jsNewsEmailButton">
-                            <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                                <i class="fa fa-envelope" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        {/if}
-                        <li class="primary_button jsNewsPostEditButton" data-news-id="{$line->getId()}">
-                            <a class="links_addnew_link">
-                                <i class="fa fa-pencil" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$line->getId()}">
-                            <a class="links_addnew_link">
-                                <i class="fa fa-trash" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        <div class="news_button_dropdown" data-dropdown-id="{$line->getId()}">
-                            <li class="primary_button">
-                                <a class="links_addnew_link">
-                                    <i class="fa fa-bars" aria-hidden="true"></i>
-                                </a>
-                            </li>
-                            <div class="dropdown_box" id="dropdown_box{$line->getId()}">
-                                <li class="dropdown_item">
-                                    <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                                        Email
-                                    </a>
-                                </li>
-                                <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$line->getId()}">
-                                    Edit
-                                </li>
-                                <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$line->getId()}">
-                                    Delete
-                                </li>
-                            </div>
-                        </div>
-                    </ul>
-                    <div class="news_line" id="line_above_info"></div>
-                    <h4 class="news_title_phoneview">
-                        {$line->getHeadline()}</a>
-                    </h4>
-                    <div class="news_post_info">
-                        Posted <span>by <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a></span> on {$line->getDate()}
-                    </div>
-                    <div class="news_line" id="line_below_info"></div>
-                    <div class="news_post_text" id="jsNewsTextBox{$line->getId()}">
-                        {if $line->getImageId() != ''}
-                            <div style="float:left;margin:15px;">
-                                <img src="../../includes/show_image.php?file={$line->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
-                            </div>
-                        {/if}
-                        <br>
-                        {$line->getText()}
-                        <br>
-                        <br>
-                    </div>
-                </div>
-            </div>
-        </div>
-    {/foreach}
-
-    {if isset($osd_message)}
-        [BRK]{$osd_message}
-    {/if}
-
+        {/foreach}
+    </select>
+    <br>
+    {html_select_date all_id="{$article->getId()}" time=$article->getDate() start_year="2000" class="standard_select"}
+    <br>
+    <br>
+    <input type="button" class="primary_button" accesskey= "b" name="addbbcode0" value="B" onclick="bbstyle(0,'textfield{$news_id}')">
+    <input type="button" class="primary_button" accesskey= "u" name="addbbcode4" value="U" onclick="bbstyle(4,'textfield{$news_id}')">
+    <input type="button" class="primary_button" accesskey= "i" name="addbbcode2" value="I" onclick="bbstyle(2,'textfield{$news_id}')">
+    <input type="button" class="primary_button" accesskey="w" name="addbbcode6" value="URL" onClick="bbstyle(6,'textfield{$news_id}')">
+    <input type="button" class="primary_button" accesskey="x" name="addbbcode8" value="@" onClick="bbstyle(8,'textfield{$news_id}')">
+    <input type="button" class="primary_button" accesskey="frontpage" name="addbbcode14" value="Frontpage" onClick="bbstyle(14,'textfield{$news_id}')">
+    <br>
+    <textarea class="primary_textarea" rows="4" name="textfield{$news_id}" id="jsNewsText" ONSELECT="javascript:storeCaret(this);" ONCLICK="javascript:storeCaret(this);" ONKEYUP="javascript:storeCaret(this);" ONCHANGE="javascript:storeCaret(this);">{$article->getText()}</textarea>
 {/if}
 
 {if isset($action) and $action=='save_news_text'}
-    {foreach from=$news item=line}
     <div class="news_userinfo_phoneview">
-        {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() !== ''}
-            <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
+        {if $article->getUser()->getAvatar() != null}
+            <img src="../../includes/show_image.php?file={$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getAvatar()}" width="100px">
         {else}
-            <img src="../../includes/show_image.php?file={$style_dir} {$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
+            <img src="../../includes/show_image.php?file={$style_dir} {$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getAvatar()}" width="100px">
         {/if}
         <h6>
-            <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a>
+            <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}">{$article->getUser()->getName()}</a>
         </h6>
     </div>
     <h4 class="news_title">
-        {$line->getHeadline()}</a>
+        {$article->getHeadline()}</a>
     </h4>
     <ul class="news_buttons">
-        {if $line->getEmail() !== ''}
+        {if $article->getUser()->getEmail() !== ''}
         <li class="primary_button jsNewsEmailButton">
-            <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
+            <a href="mailto:{$article->getUser()->getEmail()}?subject=Your news post : {$article->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
                 <i class="fa fa-envelope" aria-hidden="true"></i>
             </a>
         </li>
         {/if}
-        <li class="primary_button jsNewsPostEditButton" data-news-id="{$line->getId()}">
+        <li class="primary_button jsNewsPostEditButton" data-news-id="{$article->getId()}">
             <a class="links_addnew_link">
                 <i class="fa fa-pencil" aria-hidden="true"></i>
             </a>
         </li>
-        <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$line->getId()}">
+        <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$article->getId()}">
             <a class="links_addnew_link">
                 <i class="fa fa-trash" aria-hidden="true"></i>
             </a>
         </li>
-        <div class="news_button_dropdown" data-dropdown-id="{$line->getId()}">
+        <div class="news_button_dropdown" data-dropdown-id="{$article->getId()}">
             <li class="primary_button">
                 <a class="links_addnew_link">
                     <i class="fa fa-bars" aria-hidden="true"></i>
                 </a>
             </li>
-            <div class="dropdown_box" id="dropdown_box{$line->getId()}">
+            <div class="dropdown_box" id="dropdown_box{$article->getId()}">
                 <li class="dropdown_item">
-                    <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
+                    <a href="mailto:{$article->getUser()->getEmail()}?subject=Your news post : {$article->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
                         Email
                     </a>
                 </li>
-                <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$line->getId()}">
+                <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$article->getId()}">
                     Edit
                 </li>
-                <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$line->getId()}">
+                <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$article->getId()}">
                     Delete
                 </li>
             </div>
@@ -234,23 +120,22 @@
     </ul>
     <div class="news_line" id="line_above_info"></div>
     <h4 class="news_title_phoneview">
-        {$line->getHeadline()}</a>
+        {$article->getHeadline()}</a>
     </h4>
     <div class="news_post_info">
-        Posted <span>by <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a></span> on {$line->getDate()}
+        Posted <span>by <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}">{$article->getUser()->getName()}</a></span> on {$article->getDate()|date_format}
     </div>
     <div class="news_line" id="line_below_info"></div>
-    <div class="news_post_text" id="jsNewsTextBox{$line->getId()}">
-        {if $line->getImageId() != ''}
+    <div class="news_post_text" id="jsNewsTextBox{$article->getId()}">
+        {if $article->getImage() != null}
             <div style="float:left;margin:15px;">
-                <img src="../../includes/show_image.php?file={$line->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
+                <img src="../../includes/show_image.php?file={$article->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
             </div>
         {/if}
         <br>
-        {$line->getText()}
+        {$article->getHtmlText()}
         <br>
         <br>
     </div>
-    {/foreach}
     [BRK]{$osd_message}
 {/if}

--- a/Website/AtariLegend/themes/templates/1/admin/ajax_news_search.html
+++ b/Website/AtariLegend/themes/templates/1/admin/ajax_news_search.html
@@ -13,112 +13,103 @@ This is the sub template file to generate the news edit page
 ****************************************************************************
 *}
 
-{if $nr_news <> ''}
-    {if $nr_news <> ''}<div class="standard_tile_text_center">Your search query resulted in {$nr_news} entries.</div><br>{/if}
-    {foreach from=$news item=line}
-        <div id="jsNewsId{$line->getId()}" class="infinite-item">
-            <div class="news_post_box" id="{$line->getTimestamp()}">
-                <div class="news_userinfo">
-                    {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() != ''}
-                        <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                    {else}
-                    {/if}
-                    <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getUserName()}</a>
-                    <br><br><br>
-                    <span class="text-nowrap">
-                        Joined: {$line->getJoinDate()}
-                        <br>
-                        {if $line->getUserNewsCount() > 0}
-                            News posts:  <a href="#" data-user-id="{$line->getUserId()}" class="standard_tile_link jsUserNewsLink">{$line->getUserNewsCount()}</a>
-                        {else}
-                            News posts:  {$line->getUserNewsCount()}
+<div id="news_edit_list">
+    {if count($news) > 0}
+        <div class="standard_tile_text_center">Your search query resulted in {count($news)} entries.</div><br>
+        {foreach from=$news item=article}
+            <div id="jsNewsId{$article->getId()}" class="infinite-item">
+                <div class="news_post_box" id="{$article->getDate()}">
+                    <div class="news_userinfo">
+                        {if $article->getUser()->getAvatar() != null}
+                            <img src="../../includes/show_image.php?file={$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
                         {/if}
-                        <br>
-                        {if $line->getKarma() == '' OR $line->getKarma() == 0}
-                            Karma : 0
-                        {else}
-                            Karma: <a href="../user/user_statistics.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getKarma()}</a>
-                        {/if}
-                    </span>
-                </div>
-                <div class="news_post_detail" id="jsNewsEditBox{$line->getId()}">
-                    <div class="news_userinfo_phoneview">
-                        {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() !== ''}
-                            <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                        {else}
-                            <img src="../../includes/show_image.php?file={$style_dir} {$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                        {/if}
-                        <h6>
-                            <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a>
-                        </h6>
+                        <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}" class="standard_tile_link">{$article->getUser()->getName()}</a>
+                        <br><br><br>
+                        <span class="text-nowrap">
+                            Joined: {$article->getUser()->getJoinDate()|date_format:"d-m-y"|default:"n/a"}
+                            <br>
+                            News posts:  <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}" data-user-id="{$article->getUser()->getId()}" class="standard_tile_link jsUserNewsLink">{$article->getUser()->getNewsCount()}</a>
+                            <br>
+                            Karma: <a href="../user/user_statistics.php?user_id_selected={$article->getUser()->getId()}" class="standard_tile_link">{$article->getUser()->getKarma()}</a>
+                        </span>
                     </div>
-                    <h4 class="news_title">
-                        {$line->getHeadline()}</a>
-                    </h4>
-                    <ul class="news_buttons">
-                        {if $line->getEmail() !== ''}
-                        <li class="primary_button jsNewsEmailButton">
-                            <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                                <i class="fa fa-envelope" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        {/if}
-                        <li class="primary_button jsNewsPostEditButton" data-news-id="{$line->getId()}">
-                            <a class="links_addnew_link">
-                                <i class="fa fa-pencil" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$line->getId()}">
-                            <a class="links_addnew_link">
-                                <i class="fa fa-trash" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        <div class="news_button_dropdown" data-dropdown-id="{$line->getId()}">
-                            <li class="primary_button">
-                                <a class="links_addnew_link">
-                                    <i class="fa fa-bars" aria-hidden="true"></i>
+                    <div class="news_post_detail" id="jsNewsEditBox{$article->getId()}">
+                        <div class="news_userinfo_phoneview">
+                            {if $article->getUser()->getAvatar() != null}
+                                <img src="../../includes/show_image.php?file={$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
+                            {else}
+                                <img src="../../includes/show_image.php?file={$style_dir} {$article->getUser()->getAvatar()}&amp;resize=100,null,null,null" alt="{$article->getUser()->getName()}" width="100px">
+                            {/if}
+                            <h6>
+                                <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}">{$article->getUser()->getName()}</a>
+                            </h6>
+                        </div>
+                        <h4 class="news_title">
+                            {$article->getHeadline()}</a>
+                        </h4>
+                        <ul class="news_buttons">
+                            {if $article->getUser()->getEmail() !== ''}
+                            <li class="primary_button jsNewsEmailButton">
+                                <a href="mailto:{$article->getUser()->getEmail()}?subject=Your news post : {$article->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
+                                    <i class="fa fa-envelope" aria-hidden="true"></i>
                                 </a>
                             </li>
-                            <div class="dropdown_box" id="dropdown_box{$line->getId()}">
-                                <li class="dropdown_item">
-                                    <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                                        Email
+                            {/if}
+                            <li class="primary_button jsNewsPostEditButton" data-news-id="{$article->getId()}">
+                                <a class="links_addnew_link">
+                                    <i class="fa fa-pencil" aria-hidden="true"></i>
+                                </a>
+                            </li>
+                            <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$article->getId()}">
+                                <a class="links_addnew_link">
+                                    <i class="fa fa-trash" aria-hidden="true"></i>
+                                </a>
+                            </li>
+                            <div class="news_button_dropdown" data-dropdown-id="{$article->getId()}">
+                                <li class="primary_button">
+                                    <a class="links_addnew_link">
+                                        <i class="fa fa-bars" aria-hidden="true"></i>
                                     </a>
                                 </li>
-                                <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$line->getId()}">
-                                    Edit
-                                </li>
-                                <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$line->getId()}">
-                                    Delete
-                                </li>
+                                <div class="dropdown_box" id="dropdown_box{$article->getId()}">
+                                    <li class="dropdown_item">
+                                        <a href="mailto:{$article->getUser()->getEmail()}?subject=Your news post : {$article->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
+                                            Email
+                                        </a>
+                                    </li>
+                                    <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$article->getId()}">
+                                        Edit
+                                    </li>
+                                    <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$article->getId()}">
+                                        Delete
+                                    </li>
+                                </div>
                             </div>
+                        </ul>
+                        <div class="news_line" id="line_above_info"></div>
+                        <h4 class="news_title_phoneview">
+                            {$article->getHeadline()}</a>
+                        </h4>
+                        <div class="news_post_info">
+                            Posted <span>by <a href="../user/user_detail.php?user_id_selected={$article->getUser()->getId()}">{$article->getUser()->getName()}</a></span> on {$article->getDate()|date_format}
                         </div>
-                    </ul>
-                    <div class="news_line" id="line_above_info"></div>
-                    <h4 class="news_title_phoneview">
-                        {$line->getHeadline()}</a>
-                    </h4>
-                    <div class="news_post_info">
-                        Posted <span>by <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a></span> on {$line->getDate()}
-                    </div>
-                    <div class="news_line" id="line_below_info"></div>
-                    <div class="news_post_text" id="jsNewsTextBox{$line->getId()}">
-                        {if $line->getImageId() != ''}
-                            <div style="float:left;margin:15px;">
-                                <img src="../../includes/show_image.php?file={$line->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
-                            </div>
-                        {/if}
-                        <br>
-                        {$line->getText()}
-                        <br>
-                        <br>
+                        <div class="news_line" id="line_below_info"></div>
+                        <div class="news_post_text" id="jsNewsTextBox{$article->getId()}">
+                            {if $article->getImage() != null}
+                                <div style="float:left;margin:15px;">
+                                    <img src="../../includes/show_image.php?file={$article->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
+                                </div>
+                            {/if}
+                            <br>
+                            {$article->getHtmlText()}
+                            <br>
+                            <br>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    {/foreach}
-{else}
-    <div class="standard_tile_text_center">No news entries for your query.</div>
-{/if}
-<div id="JSnewsText" style="display:none;">{if isset($news_search)}{$news_search}{/if}</div>
-<div id="JSuserId" style="display:none;">{if isset($user_id)}{$user_id}{/if}</div>
+        {/foreach}
+    {else}
+        <div class="standard_tile_text_center">No news entries to approve.</div>
+    {/if}
+</div>

--- a/Website/AtariLegend/themes/templates/1/admin/news_edit.html
+++ b/Website/AtariLegend/themes/templates/1/admin/news_edit.html
@@ -49,120 +49,13 @@ This is the sub template file to generate the news edit page
     <div class="standard_tile_padding">
         <div class="left_nav_section">
             This is the news editing page. News posts can be changed or deleted here. As these are all approved news entries, keep in mind these changes are instantly visible on the main site! Use the left side to perform a search query on the news table.
-            {if $nr_news <> ''}There are currently {$nr_news} posts in the news table.{/if}
+            There are currently {$nr_news} posts in the news table.
         </div>
         <br>
         <br>
         <form name="post" id="post">
         <div class="jsNewsWrapper infinite-container">
-            <div id="news_edit_list">
-                {if $nr_news <> '0'}
-                    {foreach from=$news item=line}
-                        <div id="jsNewsId{$line->getId()}" class="infinite-item">
-                            <div class="news_post_box" id="{$line->getTimestamp()}">
-                                <div class="news_userinfo">
-                                    {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() != ''}
-                                        <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                                    {else}
-                                    {/if}
-                                    <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getUserName()}</a>
-                                    <br><br><br>
-                                    <span class="text-nowrap">
-                                        Joined: {$line->getJoinDate()}
-                                        <br>
-                                        {if $line->getUserNewsCount() > 0}
-                                            News posts:  <a href="#" data-user-id="{$line->getUserId()}" class="standard_tile_link jsUserNewsLink">{$line->getUserNewsCount()}</a>
-                                        {else}
-                                            News posts:  {$line->getUserNewsCount()}
-                                        {/if}
-                                        <br>
-                                        {if $line->getKarma() == '' OR $line->getKarma() == 0}
-                                            Karma : 0
-                                        {else}
-                                            Karma: <a href="../user/user_statistics.php?user_id_selected={$line->getUserId()}" class="standard_tile_link">{$line->getKarma()}</a>
-                                        {/if}
-                                    </span>
-                                </div>
-                                <div class="news_post_detail" id="jsNewsEditBox{$line->getId()}">
-                                    <div class="news_userinfo_phoneview">
-                                        {if (null !== $line->getAvatarImage()) and $line->getAvatarImage() !== ''}
-                                            <img src="../../includes/show_image.php?file={$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                                        {else}
-                                            <img src="../../includes/show_image.php?file={$style_dir} {$line->getAvatarImage()}&amp;resize=100,null,null,null" alt="{$line->getUserName()}" width="100px">
-                                        {/if}
-                                        <h6>
-                                            <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a>
-                                        </h6>
-                                    </div>
-                                    <h4 class="news_title">
-                                        {$line->getHeadline()}</a>
-                                    </h4>
-                                    <ul class="news_buttons">
-                                        {if $line->getEmail() !== ''}
-                                        <li class="primary_button jsNewsEmailButton">
-                                            <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                                                <i class="fa fa-envelope" aria-hidden="true"></i>
-                                            </a>
-                                        </li>
-                                        {/if}
-                                        <li class="primary_button jsNewsPostEditButton" data-news-id="{$line->getId()}">
-                                            <a class="links_addnew_link">
-                                                <i class="fa fa-pencil" aria-hidden="true"></i>
-                                            </a>
-                                        </li>
-                                        <li class="primary_button jsNewsPostDeleteButton" data-news-id="{$line->getId()}">
-                                            <a class="links_addnew_link">
-                                                <i class="fa fa-trash" aria-hidden="true"></i>
-                                            </a>
-                                        </li>
-                                        <div class="news_button_dropdown" data-dropdown-id="{$line->getId()}">
-                                            <li class="primary_button">
-                                                <a class="links_addnew_link">
-                                                    <i class="fa fa-bars" aria-hidden="true"></i>
-                                                </a>
-                                            </li>
-                                            <div class="dropdown_box" id="dropdown_box{$line->getId()}">
-                                                <li class="dropdown_item">
-                                                    <a href="mailto:{$line->getEmail()}?subject=Your news post : {$line->getHeadline()|escape:'url'} at Atari Legend" class="links_addnew_link">
-                                                        Email
-                                                    </a>
-                                                </li>
-                                                <li class="dropdown_item jsNewsPostEditDropdownItem" data-news-id="{$line->getId()}">
-                                                    Edit
-                                                </li>
-                                                <li class="dropdown_item jsNewsPostDeleteDropdownItem" data-news-id="{$line->getId()}">
-                                                    Delete
-                                                </li>
-                                            </div>
-                                        </div>
-                                    </ul>
-                                    <div class="news_line" id="line_above_info"></div>
-                                    <h4 class="news_title_phoneview">
-                                        {$line->getHeadline()}</a>
-                                    </h4>
-                                    <div class="news_post_info">
-                                        Posted <span>by <a href="../user/user_detail.php?user_id_selected={$line->getUserId()}">{$line->getUserName()}</a></span> on {$line->getDate()}
-                                    </div>
-                                    <div class="news_line" id="line_below_info"></div>
-                                    <div class="news_post_text" id="jsNewsTextBox{$line->getId()}">
-                                        {if $line->getImageId() != ''}
-                                            <div style="float:left;margin:15px;">
-                                                <img src="../../includes/show_image.php?file={$line->getImage()}&amp;resize=120,null,null,null" alt="newsbutton" class="game_screenshot_img">
-                                            </div>
-                                        {/if}
-                                        <br>
-                                        {$line->getText()}
-                                        <br>
-                                        <br>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    {/foreach}
-                {else}
-                    <div class="standard_tile_text_center">No news entries to approve.</div>
-                {/if}
-            </div>
+            {include file='1/admin/ajax_news_search.html'}
             <div id="JSuserId" style="display:none;">{if isset($user_id)}{$user_id}{/if}</div>
         </div>
         </form>

--- a/Website/AtariLegend/themes/templates/1/admin/quick_search_news.html
+++ b/Website/AtariLegend/themes/templates/1/admin/quick_search_news.html
@@ -38,7 +38,7 @@
             <div class="standard_tile_text_center">
                 By Author : <br>
                 <select name="author_search" id="JSCpanelAuthorBrowse" class="standard_select select_large">
-                    <option value="-" SELECTED>-</option>
+                    <option value="" SELECTED>-</option>
                     {foreach from=$authors_search item=line}
                         <option value="{$line.user_id}">{$line.user_name}</option>
                     {/foreach}

--- a/Website/AtariLegend/themes/templates/1/main/atom.xml
+++ b/Website/AtariLegend/themes/templates/1/main/atom.xml
@@ -4,7 +4,7 @@
      <title>Atari Legend - Latest News, Reviews and Interviews</title>
      <subtitle>Legends Never Die!</subtitle>
      <icon>{$smarty.const.REQUEST_SITEURL}/themes/templates/1/includes/icons/favicon.png</icon>
-     <link href="{$smarty.const.REQUEST_SITEURL}/news/" />
+     <link href="{$smarty.const.REQUEST_SITEURL}/news/news.php" />
      <link rel="self" href="{$smarty.const.REQUEST_SITEURL}/news/rss.php" />
      <updated>{$last_updated|date_format:"%Y-%m-%dT%H:%M:%SZ"}</updated>
      <author>


### PR DESCRIPTION
Initially there was an issue with the Atom feed because the value
returned by `$news->getDate()` was a formatted date (i.e. "July, 2nd
2018") and not a timestamp. I started to look at `News.php` and
`NewsDAO.php` and realized there were a few issues.

Model objects like `News.php` should only contain attributes of a news
(i.e. headline, date, etc.) and nothing else, otherwise it makes them
very difficult to re-use in different pages, and makes the code more
complex and harder to maintain. The `News` model was containing
information about the news user (userid, joined date, count of news,
etc.).

Changed it to link to a `User` object instead that can hold the user
attributes. Thus accessing the id of author of a news article becomes
`$news->getUser()->getId()`. There's now `User` model that we can re-use
elsewhere, and the `News` model stays focused on news.

I think it's the first time we had something like that, so it's fair
enough that it wasn't obvious how to deal with that case.

Also:
- Remove unused / commented code
- Re-use the same template to list news on the CPANEL, regardless if
  it's done via Ajax or not (Simply by having Smarty include the Ajax
  template in the main template, rather than duplicating the code)
- Simplified the news SQL code a bit (hopefully) and added helper
  methods to deal with a variable number of constraints (i.e. constraint
  on user id + timestamp, or user id + search words, or search words +
  timestamp, etc.)
- Rather than using a separate query to get the number of results for
  the news, just use `count()` on the resulting array
- Added a DAO for users to retrieve all users
- Fixed URL of Atom feed
- Added `admin/news/*` to the PHPCS checks and cleaned up syntax warnings