### PR TITLE
Rename columns in the `system` and `resolution` table

### DIFF
--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_enhancement_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_enhancement_table.php
@@ -20,11 +20,11 @@ AND table_name = 'game_release_system_enhanced' LIMIT 1";
 
 // Database change
 $database_update_sql = "CREATE TABLE game_release_system_enhanced (
-  `game_release_system_enhanced_id` INT NOT NULL AUTO_INCREMENT,
-  `system_id` INT NOT NULL,
-  `game_release_id` INT NOT NULL,
-  PRIMARY KEY (`game_release_system_enhanced_id`),
-  FOREIGN KEY (system_id) REFERENCES system(system_id),
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `system_id` INT NOT NULL COMMENT 'ID of the system the release is enhanced for',
+  `game_release_id` INT NOT NULL COMMENT 'ID of the release',
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (system_id) REFERENCES system(id),
   FOREIGN KEY (game_release_id) REFERENCES game_release(id)
 )
 ENGINE = InnoDB

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_incompability_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_release_system_incompability_table.php
@@ -20,11 +20,11 @@ AND table_name = 'game_release_system_incompatible' LIMIT 1";
 
 // Database change
 $database_update_sql = "CREATE TABLE game_release_system_incompatible (
-  `game_release_system_incompatible_id` INT NOT NULL AUTO_INCREMENT,
-  `system_id` INT NOT NULL,
-  `game_release_id` INT NOT NULL,
-  PRIMARY KEY (`game_release_system_incompatible_id`),
-  FOREIGN KEY (system_id) REFERENCES system(system_id),
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `system_id` INT NOT NULL COMMENT 'ID of the system the release is incompatible with',
+  `game_release_id` INT NOT NULL COMMENT 'ID of the release',
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (system_id) REFERENCES system(id),
   FOREIGN KEY (game_release_id) REFERENCES game_release(id)
 )
 ENGINE = InnoDB

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_system_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_create_system_table.php
@@ -20,9 +20,9 @@ AND table_name = 'system' LIMIT 1";
 
 // Database change
 $database_update_sql = "CREATE TABLE system (
-    `system_id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a system',
-    `system_name` VARCHAR(255) NOT NULL COMMENT 'Name of computer system',
-    PRIMARY KEY (`system_id`)
+    `id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a system',
+    `name` VARCHAR(255) NOT NULL COMMENT 'Name of computer system',
+    PRIMARY KEY (`id`)
 )
 ENGINE = InnoDB
 CHARSET = utf8

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_populate_system_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-26_populate_system_table.php
@@ -21,7 +21,7 @@ AND table_name = 'system' LIMIT 1";
 // Database change
 $database_update_sql = "
 INSERT INTO system
-  (system_name)
+  (name)
 VALUES
   ('Falcon'),
   ('STE'),

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_release_resolution_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_release_resolution_table.php
@@ -20,11 +20,11 @@ AND table_name = 'game_release_resolution' LIMIT 1";
 
 // Database change
 $database_update_sql = "CREATE TABLE game_release_resolution (
-  `game_release_resolution_id` INT NOT NULL AUTO_INCREMENT,
-  `resolution_id` INT NOT NULL,
-  `game_release_id` INT NOT NULL,
-  PRIMARY KEY (`game_release_resolution_id`),
-  FOREIGN KEY (resolution_id) REFERENCES resolution(resolution_id),
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `resolution_id` INT NOT NULL COMMENT 'ID of a screen resolution the game supports',
+  `game_release_id` INT NOT NULL COMMENT 'ID of the release',
+  PRIMARY KEY (`id`),
+  FOREIGN KEY (resolution_id) REFERENCES resolution(id),
   FOREIGN KEY (game_release_id) REFERENCES game_release(id)
 )
 ENGINE = InnoDB

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_resolution_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_create_resolution_table.php
@@ -20,9 +20,9 @@ AND table_name = 'resolution' LIMIT 1";
 
 // Database change
 $database_update_sql = "CREATE TABLE resolution (
-    `resolution_id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a screen resolution',
-    `resolution_name` VARCHAR(255) NOT NULL COMMENT 'Name of screen resolution',
-    PRIMARY KEY (`resolution_id`)
+    `id` INT NOT NULL AUTO_INCREMENT COMMENT 'Unique ID of a screen resolution',
+    `name` VARCHAR(255) NOT NULL COMMENT 'Name of screen resolution',
+    PRIMARY KEY (`id`)
 )
 ENGINE = InnoDB
 CHARSET = utf8

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_populate_resolution_table.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-02-27_populate_resolution_table.php
@@ -21,7 +21,7 @@ AND table_name = 'resolution' LIMIT 1";
 // Database change
 $database_update_sql = "
 INSERT INTO resolution
-  (resolution_name)
+  (name)
 VALUES
   ('ST Low'),
   ('ST Medium'),

--- a/Website/AtariLegend/php/admin/games/games_detail.php
+++ b/Website/AtariLegend/php/admin/games/games_detail.php
@@ -278,32 +278,6 @@ while ($aka = $sql_aka->fetch_array(MYSQLI_BOTH)) {
 $smarty->assign("nr_aka", $nr_aka);
 
 //***********************************************************************************
-// Systems list
-//***********************************************************************************
-
-$sql_system = $mysqli->query("SELECT * FROM system") or die("Couldn't query system list");
-
-while ($system_list = $sql_system->fetch_array(MYSQLI_BOTH)) {
-    $smarty->append('system_list', array(
-        'system_id' => $system_list['system_id'],
-        'system_name' => $system_list['system_name']
-    ));
-}
-
-//***********************************************************************************
-// Resolutions list
-//***********************************************************************************
-
-$sql_resolution = $mysqli->query("SELECT * FROM resolution") or die("Couldn't query resolution list");
-
-while ($resolution_list = $sql_resolution->fetch_array(MYSQLI_BOTH)) {
-    $smarty->append('resolution_list', array(
-        'resolution_id' => $resolution_list['resolution_id'],
-        'resolution_name' => $resolution_list['resolution_name']
-    ));
-}
-
-//***********************************************************************************
 //The game statistics below on the page
 //***********************************************************************************
 

--- a/Website/AtariLegend/php/common/DAO/ResolutionDAO.php
+++ b/Website/AtariLegend/php/common/DAO/ResolutionDAO.php
@@ -21,20 +21,20 @@ class ResolutionDAO {
         $stmt = \AL\Db\execute_query(
             "ResolutionDAO: getAllResolutions",
             $this->mysqli,
-            "SELECT resolution_id, resolution_name FROM resolution ORDER BY resolution_id",
+            "SELECT id, name FROM resolution ORDER BY id",
             null, null
         );
 
         \AL\Db\bind_result(
             "ResolutionDAO: getAllResolutions",
             $stmt,
-            $resolution_id, $resolution_name
+            $id, $name
         );
 
         $resolutions = [];
         while ($stmt->fetch()) {
             $resolutions[] = new \AL\Common\Model\Game\Resolution(
-                $resolution_id, $resolution_name
+                $id, $name
             );
         }
 

--- a/Website/AtariLegend/php/common/DAO/SystemDAO.php
+++ b/Website/AtariLegend/php/common/DAO/SystemDAO.php
@@ -23,20 +23,20 @@ class SystemDAO {
         $stmt = \AL\Db\execute_query(
             "SystemDAO: getAllSystems",
             $this->mysqli,
-            "SELECT system_id, system_name FROM system ORDER by system_name",
+            "SELECT id, name FROM system ORDER by name",
             null, null
         );
 
         \AL\Db\bind_result(
             "SystemDAO: getAllSystems",
             $stmt,
-            $system_id, $system_name
+            $id, $name
         );
 
         $systems = [];
         while ($stmt->fetch()) {
             $systems[] = new \AL\Common\Model\Game\System(
-                $system_id, $system_name
+                $id, $name
             );
         }
 


### PR DESCRIPTION
Confirm to naming convention of not prefixing columns with the table
name.