### PR TITLE
Ensure `grunt watch` is always run on the Docker image

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ../:/app
     working_dir: /app
-    command: bash -c "npm rebuild node-sass && npm run grunt && npm run grunt -- watch"
+    command: bash -c "npm rebuild node-sass; npm run grunt; npm run grunt -- watch"
   # Convenience phpMyAdmin image to administer the database
   phpmyadmin:
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
In some cases running `grunt` may fail (if PHPCS finds an error for
example) causing `grunt watch` to never be run (as it's chained with
`&&`). Replace that with `;` which will just chain the commands without
considering their exit code, so that `grunt watch` will always run even
if the initial `grunt` fails.