### PR TITLE
Fix game description metadata

### DIFF
--- a/Website/AtariLegend/php/main/games/games_detail.php
+++ b/Website/AtariLegend/php/main/games/games_detail.php
@@ -59,7 +59,7 @@ function generate_game_description(
     if ($game_releases) {
         $years = [];
         foreach ($game_releases as $release) {
-            $years[] += strtotime($release->getDate()); 
+            $years[] += date("Y", strtotime($release->getDate()));
         }
         $desc .= "released in ".join($years, ", ");
     }


### PR DESCRIPTION
The year is a timestamp so it needs to be converted to a string with
`date()`.