### PR TITLE
Associate publishers to release

### DIFF
--- a/Sources/styles/1/scss/_form_components.scss
+++ b/Sources/styles/1/scss/_form_components.scss
@@ -84,7 +84,10 @@
     color: #ffffff;
     border: 1px solid #008b8b;
     text-align: left;
+}
 
+.standard_input,
+.standard_select {
     &:disabled {
         border: dotted 1px #666;
         background-color: #222;
@@ -92,6 +95,8 @@
         cursor: not-allowed;
     }
 }
+
+
 .input_small {
     width: 50px;
 }

--- a/Sources/styles/1/scss/_tables.scss
+++ b/Sources/styles/1/scss/_tables.scss
@@ -145,6 +145,12 @@
     background-color: #006f6f;
 }
 
+.secondary_table_list td.secondary_table_separator {
+    background-color: #122323;
+
+}
+
+
 
 //
 // Table customizations

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_add_game_release_continent_id.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_add_game_release_continent_id.php
@@ -1,0 +1,33 @@
+<?php
+/***************************************************************************
+ * Add the continent_id column on the game_release table
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 152;
+
+// Description of what the change will do.
+$update_description = "Add the continent_id column on the game_release table";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_fail";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.columns
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_release'
+AND column_name = 'continent_id' LIMIT 1";
+
+// Database change
+$database_update_sql = "ALTER TABLE game_release
+ADD `continent_id` INT NULL COMMENT 'Continent where the release took place',
+ADD FOREIGN KEY (continent_id) REFERENCES continent(continent_id)";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_add_game_release_pub_dev_id.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_add_game_release_pub_dev_id.php
@@ -1,0 +1,33 @@
+<?php
+/***************************************************************************
+ * Add the pub_dev_id column on the game_release table
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 153;
+
+// Description of what the change will do.
+$update_description = "Add the pub_dev_id column on the game_release table";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_fail";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.columns
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_release'
+AND column_name = 'pub_dev_id' LIMIT 1";
+
+// Database change
+$database_update_sql = "ALTER TABLE game_release
+ADD `pub_dev_id` INT NULL COMMENT 'Publisher of the release',
+ADD FOREIGN KEY (pub_dev_id) REFERENCES pub_dev(pub_dev_id)";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_add_game_release_type.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_add_game_release_type.php
@@ -1,0 +1,33 @@
+<?php
+/***************************************************************************
+ * Add the type column on the game_release table
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 151;
+
+// Description of what the change will do.
+$update_description = "Add the type column on the game_release table";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_fail";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM information_schema.columns
+WHERE table_schema = '$db_databasename'
+AND table_name = 'game_release'
+AND column_name = 'type' LIMIT 1";
+
+// Database change
+$database_update_sql = "ALTER TABLE game_release
+ADD `type` ENUM('Re-release','Budget','Budget re-release')
+COMMENT 'Optional type of the release'";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_game_publisher_continent_id_null_values.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_game_publisher_continent_id_null_values.php
@@ -1,0 +1,29 @@
+<?php
+/*************************************************************************************************
+ *   Replace 0 values in game_publisher.continent_id by NULLs
+ ************************************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 154;
+
+// Description of what the change will do.
+$update_description = "Replace 0 values in game_publisher.continent_id by NULLs";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_success";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM game_publisher
+WHERE continent_id = 0";
+
+// Database change
+$database_update_sql = "UPDATE game_publisher SET continent_id = NULL WHERE continent_id = 0";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_merge_publishers_into_releases.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_merge_publishers_into_releases.php
@@ -1,0 +1,32 @@
+<?php
+/***************************************************************************
+ * Merge publishers into game releases
+ **************************************************************************/
+
+// Unique identifier set by developer.
+$database_update_id = 155;
+
+// Description of what the change will do.
+$update_description = "Merge publishers into game releases";
+
+// Should the database change query execute if test is "test_fail" or "test_success"
+$execute_condition = "test_fail";
+
+//This is the test query, the query should be made to get an either true or false result.
+$test_condition = "SELECT *
+FROM game_release
+WHERE `type` IS NOT NULL
+AND continent_id IS NOT NULL
+AND pub_dev_id IS NOT NULL
+LIMIT 1";
+
+// Database change
+$database_update_sql = "../../admin/administration/database_scripts/2018-07-18_merge_publishers_into_releases_addition.php";
+
+// If the update should auto execute without user interaction set to "yes".
+$database_autoexecute = "yes";
+
+// This var should almost allways be set to "no", it is only used for certain corner cases where
+// the database change has already been done in some other way and we only want to update the
+// change database.
+$force_insert = "no";

--- a/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_merge_publishers_into_releases_addition.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/2018-07-18_merge_publishers_into_releases_addition.php
@@ -1,0 +1,62 @@
+<?php
+
+// Select all games that have a single release and a single publisher
+$result = $mysqli->query("
+    SELECT DISTINCT game_id FROM game
+    WHERE game_id IN (
+        SELECT
+            game_id
+        FROM
+            game_release
+        GROUP BY
+            game_id
+        HAVING
+            COUNT(game_id) = 1
+    )
+    AND game_id IN (
+        SELECT
+            game_id
+        FROM
+            game_publisher
+        GROUP BY
+            game_id
+        HAVING
+            COUNT(game_id) = 1
+    )
+    ") or die($mysqli->error);
+
+while ($games = $result->fetch_array(MYSQLI_BOTH)) {
+    $game_id = $games['game_id'];
+
+    // Select the single publisher information for this game
+    $publisher_result = $mysqli->query("
+        SELECT pub_dev_id, continent_id, game_extra_info_id
+        FROM game_publisher
+        WHERE game_id = $game_id")
+        or die($mysqli->error);
+    $publisher = $publisher_result->fetch_array(MYSQLI_BOTH) or die ($mysqli->error);
+
+    $continent_id = 'NULL';
+    if ($publisher['continent_id'] != null) {
+        $continent_id = $publisher['continent_id'];
+    }
+
+    $type = 'NULL';
+    if ($publisher['game_extra_info_id'] == 1) {
+        $type = "'Budget'";
+    }
+
+    // Since there's a single release, we can update it directly
+    $mysqli->query("
+        UPDATE game_release
+        SET pub_dev_id = ".$publisher['pub_dev_id'].",
+        continent_id = $continent_id,
+        type = $type
+        WHERE game_id = $game_id")
+        or die("Failed to update game $game_id: ".$mysqli->error);
+
+    // Remove the publisher we just merged
+    $mysqli->query("DELETE FROM game_publisher WHERE pub_dev_id = ".$publisher['pub_dev_id']." AND game_id = $game_id")
+        or die($mysqli->error);
+
+}

--- a/Website/AtariLegend/php/admin/common/autocomplete.php
+++ b/Website/AtariLegend/php/admin/common/autocomplete.php
@@ -33,14 +33,14 @@ switch ($extraParams) {
         $stmt->execute();
         $stmt->bind_result($user_id, $userid);
 
-    while ($stmt->fetch()) {
-        array_push(
-            $json,
-            array(
-            "value" => $user_id,
-            "label" => $userid)
-        );
-    }
+        while ($stmt->fetch()) {
+            array_push(
+                $json,
+                array(
+                "value" => $user_id,
+                "label" => $userid)
+            );
+        }
         $stmt->close();
         break;
 
@@ -56,17 +56,17 @@ switch ($extraParams) {
         $stmt->execute();
         $stmt->bind_result($ind_id, $ind_name);
 
-    while ($stmt->fetch()) {
-        array_push(
-            $json,
-            array(
-            "value" => $ind_id,
-            "label" => $ind_name)
-        );
-    }
+        while ($stmt->fetch()) {
+            array_push(
+                $json,
+                array(
+                "value" => $ind_id,
+                "label" => $ind_name)
+            );
+        }
         $stmt->close();
         break;
-        
+
     case "game":
         $stmt = $mysqli->prepare("
             SELECT game_id, game_name
@@ -79,16 +79,40 @@ switch ($extraParams) {
         $stmt->execute();
         $stmt->bind_result($game_id, $game_name);
 
-    while ($stmt->fetch()) {
-        array_push(
-            $json,
-            array(
-            "value" => $game_id,
-            "label" => $game_name)
-        );
-    }
+        while ($stmt->fetch()) {
+            array_push(
+                $json,
+                array(
+                "value" => $game_id,
+                "label" => $game_name)
+            );
+        }
         $stmt->close();
         break;
+
+    case "pub_dev":
+        $stmt = $mysqli->prepare("
+            SELECT pub_dev_id, pub_dev_name
+            FROM pub_dev
+            WHERE LOWER(pub_dev_name) LIKE CONCAT('%',LOWER(?),'%')")
+        or
+        die("Error querying pub_dev: ".$mysqli->error);
+
+        $stmt->bind_param("s", $term);
+        $stmt->execute();
+        $stmt->bind_result($pub_dev_id, $pub_dev_name);
+
+        while ($stmt->fetch()) {
+            array_push(
+                $json,
+                array(
+                "value" => $pub_dev_id,
+                "label" => $pub_dev_name)
+            );
+        }
+        $stmt->close();
+        break;
+
 }
 
 header("Content-Type: application/json");

--- a/Website/AtariLegend/php/admin/games/games_publishers_to_merge.php
+++ b/Website/AtariLegend/php/admin/games/games_publishers_to_merge.php
@@ -1,0 +1,81 @@
+<?php
+
+include("../../config/common.php");
+include("../../config/admin.php");
+require_once __DIR__."/../../lib/Db.php" ;
+
+$stmt = \AL\Db\execute_query(
+    "games_publishers_to_merge",
+    $mysqli,
+    "SELECT * FROM
+    (
+        SELECT
+            game.game_id,
+            game.game_name,
+            pub_dev.pub_dev_id,
+            pub_dev.pub_dev_name,
+            continent.continent_name,
+            game_extra_info.game_extra_info,
+            ''
+        FROM
+            game
+        LEFT JOIN game_publisher ON game_publisher.game_id = game.game_id
+        LEFT JOIN pub_dev ON game_publisher.pub_dev_id = pub_dev.pub_dev_id
+        LEFT JOIN continent ON game_publisher.continent_id = continent.continent_id
+        LEFT JOIN game_extra_info ON game_publisher.game_extra_info_id = game_extra_info.game_extra_info_id
+
+        UNION
+
+        SELECT
+            game.game_id,
+            game.game_name,
+            '',
+            '',
+            '',
+            '',
+            YEAR(game_release.date)
+        FROM
+            game
+        LEFT JOIN game_release ON game_release.game_id = game.game_id
+    ) AS T
+    WHERE game_id IN
+    (
+        SELECT
+            game_id
+        FROM
+            game_publisher
+    )
+    ORDER BY
+        game_name ASC",
+    null, null
+);
+
+\AL\Db\bind_result(
+    "games_publishers_to_merge",
+    $stmt,
+    $game_id, $game_name, $pub_dev_id, $pub_dev_name, $continent_name, $game_extra_info, $release_date
+);
+
+$previous_game_id = -1;
+while ($stmt->fetch()) {
+    if ($previous_game_id != $game_id) {
+        $smarty->append('rows', 'separator');
+        $previous_game_id = $game_id;
+    }
+
+    $smarty->append('rows', array(
+        'game_id' => $game_id,
+        'game_name' => $game_name,
+        'pub_dev_id' => $pub_dev_id,
+        'pub_dev_name' => $pub_dev_name,
+        'continent_name' => $continent_name,
+        'game_extra_info' => $game_extra_info,
+        'release_date' => $release_date
+    ));
+}
+
+$stmt->close();
+
+$smarty->display("file:" . $cpanel_template_folder . "games_publishers_to_merge.html");
+
+mysqli_close($mysqli);

--- a/Website/AtariLegend/php/common/DAO/ContinentDAO.php
+++ b/Website/AtariLegend/php/common/DAO/ContinentDAO.php
@@ -1,0 +1,49 @@
+<?php
+namespace AL\Common\DAO;
+
+require_once __DIR__."/../../lib/Db.php" ;
+require_once __DIR__."/../Model/Continent/Continent.php" ;
+
+/**
+ * DAO for Continent
+ */
+class ContinentDAO {
+    private $mysqli;
+
+    public function __construct($mysqli) {
+        $this->mysqli = $mysqli;
+    }
+
+    /**
+     * Get all the continents
+     * @return \AL\Common\Model\Continent\Continent[] An array of Continents
+     */
+    public function getAllContinents() {
+        $stmt = \AL\Db\execute_query(
+            "ContinentDAO: getAllContinents",
+            $this->mysqli,
+            "SELECT continent_id, continent_name
+            FROM continent
+            ORDER BY continent_id ASC",
+            null, null
+        );
+
+        \AL\Db\bind_result(
+            "ContinentDAO: getAllContinents",
+            $stmt,
+            $id, $name
+        );
+
+        $continents = [];
+        while ($stmt->fetch()) {
+            $continents[] = new \AL\Common\Model\Continent\Continent(
+                $id,
+                $name
+            );
+        }
+
+        $stmt->close();
+
+        return $continents;
+    }
+}

--- a/Website/AtariLegend/php/common/DAO/PubDevDAO.php
+++ b/Website/AtariLegend/php/common/DAO/PubDevDAO.php
@@ -14,6 +14,9 @@ class PubDevDAO {
         $this->mysqli = $mysqli;
     }
 
+    public function getAllPubDevs() {
+        return $this->getPubDevsStartingWith(".");
+    }
     /**
      * Get all publishers and developers
      * @return \AL\Common\Model\PubDev\PubDev[] A list of PubDevs

--- a/Website/AtariLegend/php/common/Model/Continent/Continent.php
+++ b/Website/AtariLegend/php/common/Model/Continent/Continent.php
@@ -1,0 +1,23 @@
+<?php
+namespace AL\Common\Model\Continent;
+
+/**
+ * Maps to the `continent` table
+ */
+class Continent {
+    private $id;
+    private $name;
+
+    public function __construct($id, $name) {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
+    public function getId() {
+        return $this->id;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+}

--- a/Website/AtariLegend/php/common/Model/Game/GameRelease.php
+++ b/Website/AtariLegend/php/common/Model/Game/GameRelease.php
@@ -10,13 +10,19 @@ class GameRelease {
     private $name;
     private $date;
     private $license;
+    private $type;
+    private $continent;
+    private $publisher;
 
-    public function __construct($id, $game_id, $name, $date, $license) {
+    public function __construct($id, $game_id, $name, $date, $license, $type, $continent, $publisher) {
         $this->id = $id;
         $this->game_id = $game_id;
         $this->name = $name;
         $this->date = $date;
         $this->license = $license;
+        $this->type = $type;
+        $this->continent = $continent;
+        $this->publisher = $publisher;
     }
 
     public function getId() {
@@ -37,5 +43,17 @@ class GameRelease {
 
     public function getLicense() {
         return $this->license;
+    }
+
+    public function getType() {
+        return $this->type;
+    }
+
+    public function getContinent() {
+        return $this->continent;
+    }
+
+    public function getPublisher() {
+        return $this->publisher;
     }
 }

--- a/Website/AtariLegend/php/main/games/games_detail.php
+++ b/Website/AtariLegend/php/main/games/games_detail.php
@@ -18,10 +18,14 @@ include("../../config/common.php");
 require_once __DIR__."/../../common/DAO/GameReleaseDAO.php";
 require_once __DIR__."/../../common/DAO/ResolutionDAO.php";
 require_once __DIR__."/../../common/DAO/SystemDAO.php";
+require_once __DIR__."/../../common/DAO/PubDevDAO.php";
+require_once __DIR__."/../../common/DAO/ContinentDAO.php";
 
 $gameReleaseDao = new \AL\Common\DAO\GameReleaseDAO($mysqli);
 $resolutionDao = new \AL\Common\DAO\ResolutionDao($mysqli);
 $systemDao = new \AL\Common\DAO\SystemDao($mysqli);
+$pubDevDao = new \AL\Common\DAO\PubDevDAO($mysqli);
+$continentDao = new \AL\Common\DAO\ContinentDAO($mysqli);
 
 /**
  * Generates an SEO-friendly description of a game, depending on the data available

--- a/Website/AtariLegend/themes/templates/1/admin/games_detail.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_detail.html
@@ -73,23 +73,6 @@
 {block name=java_script}
 <script>
 
-function browseCompany(str) {
-    if (str == "") {
-        $('#ajax_publisher_browse').html('');
-    } else {
-        $.ajaxQueue({
-            // The URL for the request
-            url: '../games/ajax_games_detail.php',
-            data: 'action=company_publisher_browse&query='+str,
-            type: 'GET',
-            dataType: 'html',
-            // Code to run if the request succeeds;
-            success: function (html) {
-                $('#ajax_publisher_browse').html(html);
-            }
-        });
-    }
-}
 function browseDeveloper(str) {
     if (str == "") {
         $('#ajax_developer_browse').html('');
@@ -460,11 +443,20 @@ $('#input-tags3').selectize({
                     </form>
                 </div>
                 <br>
-                <div id="gd_publisher_info">
-                    <fieldset class="secondary_fieldset">
-                        <legend class="primary_legend">Publisher info</legend>
 
-                        {if isset($publishers)}
+                {if isset($publishers)}
+                    <div id="gd_publisher_info">
+                        <fieldset class="secondary_fieldset">
+                            <legend class="primary_legend">Publisher info</legend>
+
+                            <div class="help-hint">
+                                <span class="fa fa-warning"></span> No new publishers can be added. Publisher should be associated to releases
+                                rather than directly to games. Use the releases menu on the left to navigate releases.
+                                This section is kept to allow manual merging of publishers into releases, and will be removed
+                                when this merging is complete.
+                            </div>
+                            <br>
+
                             {foreach from=$publishers item=publisher}
                                 <form action="db_games_publisher.php" method="get">
                                     <a title="Remove {$publisher.pub_dev_name|escape:"html"} from this game"
@@ -481,8 +473,7 @@ $('#input-tags3').selectize({
 
                                     <input type="text" value="{$publisher.pub_dev_name}" class="standard_input input_large" disabled>
 
-                                    <select name="new_continent_id"
-                                        onchange="jQuery('#update-publisher-{$publisher.pub_dev_id}').show()"
+                                    <select name="new_continent_id" disabled
                                         class="standard_select select_medium">
                                         <option value="">-</option>
                                         {foreach from=$continents item=continent}
@@ -490,8 +481,7 @@ $('#input-tags3').selectize({
                                         {/foreach}
                                     </select>
 
-                                    <select name="new_game_extra_info_id"
-                                        onchange="jQuery('#update-publisher-{$publisher.pub_dev_id}').show()"
+                                    <select name="new_game_extra_info_id" disabled
                                         class="standard_select select_medium">
                                         <option value="">-</option>
                                         {foreach from=$game_extra_info item=info}
@@ -499,51 +489,21 @@ $('#input-tags3').selectize({
                                         {/foreach}
                                     </select>
 
-                                    <input type="submit" id="update-publisher-{$publisher.pub_dev_id}" style="display: none;" class="secondary_button" value="Update">
+                                    &nbsp; Assign to release:
+                                    <a href="games_release_detail.php?game_id={$game->getId()}&amp;pub_dev_id={$publisher.pub_dev_id}&amp;continent_id={$publisher.continent_id}{if $publisher.game_extra_info_id == 1}&amp;type=Budget{/if}">[new release]</a>
+                                    {foreach from=$game_releases item=release}
+                                        {if $release->getPublisher() == null}
+                                            <a href="db_games_publisher.php?action=associate_to_release&amp;game_release_id={$release->getId()}&amp;game_id={$game->getId()}&amp;pub_dev_id={$publisher.pub_dev_id}&amp;continent_id={$publisher.continent_id}&amp;game_extra_info_id={$publisher.game_extra_info_id}"
+                                                onclick="javascript:return confirm('{$publisher.pub_dev_name|escape:"quotes"} will be associated to the {$release->getDate()|date_format:"Y"} release, along with the continent and type, then removed from the game')">
+                                                {$release->getDate()|date_format:"Y"}</a>
+                                        {/if}
+                                    {/foreach}
 
                                 </form>
                             {/foreach}
-                        {/if}
-
-                        <hr class="separator_add">
-
-                        <form action="../games/db_games_publisher.php" method="post" name="publisher" id="publisher">
-                            <input type="hidden" name="game_id" value="{$game_id}">
-                            <input type="hidden" name="action" value="add">
-
-                            <span class="fa fa-fw"></span>
-                            <select name="companybrowse" onchange="browseCompany(this.value)" class="standard_select select_small">
-                                <option value="" SELECTED>-</option>
-                                {html_options values=$az_value output=$az_output}
-                            </select>
-
-                            <span id="ajax_publisher_browse">
-                                <select name="pub_dev_id" class="standard_select select_medium" style="width: 131px" required>
-                                    <option value="" selected="selected" disabled>0-9 &hellip;</option>
-                                    {foreach from=$pubdevs item=pubdev}
-                                        <option value="{$pubdev->getId()}">{$pubdev->getName()}</option>
-                                    {/foreach}
-                                </select>
-                            </span>
-
-                            <select name="continent_id" class="standard_select select_medium">
-                                <option value="" selected="selected">-</option>
-                                {foreach from=$continents item=continent}
-                                    <option value="{$continent.continent_id}">{$continent.continent_name}</option>
-                                {/foreach}
-                            </select>
-
-                            <select name="game_extra_info_id" class="standard_select select_medium">
-                                <option value="" selected="selected">-</option>
-                                {foreach from=$game_extra_info item=line}
-                                    <option value="{$line.game_extra_info_id}">{$line.game_extra_info}</option>
-                                {/foreach}
-                            </select>
-
-                            <input type="submit" value="Add new publisher" class="secondary_button">
-                        </form>
-                    </fieldset>
-                </div>
+                        </fieldset>
+                    </div>
+                {/if}
             </div>
             <div id="gd_bottom">
                 <div id="gd_back">

--- a/Website/AtariLegend/themes/templates/1/admin/games_publishers_to_merge.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_publishers_to_merge.html
@@ -1,0 +1,45 @@
+{extends file='1/admin/main.html'} {block name=main_tile}
+<div class="standard_tile">
+    <h1>GAME PUBLISHERS TO MERGE</h1>
+
+    <div class="standard_tile_line"></div>
+
+        <div class="standard_tile_padding">
+            <div class="left_nav_section">
+                This page lists all the games that still have publishers attached
+                to them. They need to be merged into releases.
+            </div>
+
+            <br>
+
+            <table class="secondary_table_list table_hover table_sm text-nowrap">
+                <tbody>
+                    <tr>
+                        <th>Game name</th>
+                        <th>Publisher name</th>
+                        <th>Continent</th>
+                        <th>Extra info</th>
+                        <th>Release date</th>
+                    </tr>
+                    {foreach from=$rows item=row}
+                        {if $row == 'separator'}
+                            <tr>
+                                <td colspan="5" class="secondary_table_separator">&nbsp;</td>
+                            </tr>
+                        {else}
+                            <tr>
+                                <td><a href="games_detail.php?game_id={$row.game_id}#gd_publisher_info" class="standard_tile_text_left">{$row.game_name}</a></td>
+                                <td>{$row.pub_dev_name|default:'-'}</td>
+                                <td>{$row.continent_name|default}</td>
+                                <td>{$row.game_extra_info|default}</td>
+                                <td>{$row.release_date|default:'-'}</td>
+                            </tr>
+                        {/if}
+                    {/foreach}
+                </tbody>
+            </table>
+
+    </div>
+
+</div>
+{/block}

--- a/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
@@ -5,6 +5,16 @@
     {include file='1/admin/games_release_list.html'}
 {/block}
 
+{block name=additional_scripts}
+    <script src="{$template_dir}includes/js/ui.widgets.js"></script><!-- The autocomplete and dropdown switcher -->
+    <script>
+        $(document).ready(function () {
+            $('select[name=pub_dev_id]').altAutocomplete();
+        });
+    </script>
+{/block}
+
+
 {extends file='1/admin/main.html'} {block name=main_tile}
 <div class="standard_tile">
     {if isset ($release)}
@@ -48,8 +58,45 @@
                 <b>License</b>
                 <select name="license" class="standard_select select_large">
                     {foreach from=$license_types item=type}
-                    {$type}
-                    <option {if $type == $release->getLicense()}selected{/if}>{$type}</option>
+                        <option {if $type == $release->getLicense()}selected{/if}>{$type}</option>
+                    {/foreach}
+                </select>
+                <br>
+
+                <b>Type</b>
+                <select name="type" class="standard_select select_large">
+                    <option value="">-</option>
+                    {foreach from=$release_types item=release_type}
+                        <option {if $release_type == $release->getType() or (isset($type) and $type == $release_type)}selected{/if}>{$release_type}</option>
+                    {/foreach}
+                </select>
+                <br>
+
+                <b>Continent</b>
+                <select name="continent_id" class="standard_select select_large">
+                    <option value="">-</option>
+                    {foreach from=$continents item=continent}
+                        <option value="{$continent->getId()}" {if ($release->getContinent() != null and $continent->getId() == $release->getContinent()->getId()) or (isset($continent_id) and $continent_id == $continent->getId())}selected{/if}>{$continent->getName()}</option>
+                    {/foreach}
+                </select>
+                <br>
+
+                <b>Publisher</b>
+                <a href="javascript:;"
+                    class="left_nav_link"
+                    id="pubdev_select_toggle"
+                    title="Click for dropdown mode">
+                    <i class="fa fa-fw fa-chevron-circle-down" aria-hidden="true"></i>
+                </a>
+
+                <select name="pub_dev_id"
+                    class="standard_select select_large"
+                    data-alt-autocomplete-endpoint="../common/autocomplete.php?extraParams=pub_dev"
+                    data-alt-autocomplete-toggle="#pubdev_select_toggle"
+                    data-alt-autocomplete-placeholder="Start typing a publisher name…">
+                    <option value="">-</option>
+                    {foreach from=$publishers item=publisher}
+                        <option value="{$publisher->getId()}" {if ($release->getPublisher() != null and $publisher->getId() == $release->getPublisher()->getId()) or (isset($pub_dev_id) and $pub_dev_id == $publisher->getId())}selected{/if}>{$publisher->getName()}</option>
                     {/foreach}
                 </select>
 

--- a/Website/AtariLegend/themes/templates/1/admin/games_release_list.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_release_list.html
@@ -8,20 +8,22 @@
             <ul class="navigation-list">
                 {foreach from=$game_releases item=release}
                     <li {if isset($release_id) and $release->getId() == $release_id}class="active"{/if}>
+                        <a title="Delete release"
+                            href="db_games_detail.php?action=delete_release&amp;game_id={$game->getId()}&amp;game_release_id[]={$release->getId()}"
+                            onclick="javascript:return confirm('This release will be deleted');">
+                            <i class="fa fa-fw fa-trash" aria-hidden="true"></i>
+                        </a>
+
                         <a href="games_release_detail.php?release_id={$release->getId()}">
                             {if $release->getDate()}
                                 {$release->getDate()|date_format:"%Y"}
                             {else}
-                                [unknown date]
+                                [no date]
                             {/if}
                             {if $release->getName() != null} <small> as "{$release->getName()}"</small>{/if}
+                            {if $release->getPublisher() != null} <small> by {$release->getPublisher()->getName()}</small>{/if}
                         </a>
 
-                        <a title="Delete release"
-                            href="db_games_detail.php?action=delete_release&amp;game_id={$game->getId()}&amp;game_release_id[]={$release->getId()}"
-                            onclick="javascript:return confirm('This release will be deleted');">
-                            <i class="fa fa-trash" aria-hidden="true"></i>
-                        </a>
                     </li>
                 {/foreach}
             </ul>

--- a/Website/AtariLegend/themes/templates/1/admin/main.html
+++ b/Website/AtariLegend/themes/templates/1/admin/main.html
@@ -76,6 +76,7 @@
                                         <li><button class="sidebutton" id="games_side">GAMES</button>
                                             <ul class="sub-menu">
                                                 <li><a href="../games/games_main.php" title="Game editor" class="sidebutton_cpanel">GAME EDITOR</a></li>
+                                                <li><a href="../games/games_publishers_to_merge.php" title="Game publishers to merge" class="sidebutton_cpanel">GAME PUBLISHERS TO MERGE</a></li>
                                                 <li><a href="../games/games_series_main.php" title="Game series" class="sidebutton_cpanel">GAME SERIES</a></li>
                                                 <li><a href="../games/games_music.php" title="Game music" class="sidebutton_cpanel">GAME MUSIC</a></li>
                                                 <li><a href="../games/submission_games.php" title="Game submissions" class="sidebutton_cpanel">GAME SUBMISSIONS</a></li>
@@ -293,6 +294,7 @@
                         <li><button type="button" class="topbutton" id="games">GAMES</button>
                             <ul>
                                 <li><a href="../games/games_main.php" title="Game editor" class="subbutton">GAME EDITOR</a></li>
+                                <li><a href="../games/games_publishers_to_merge.php" title="Game publishers to merge" class="subbutton">GAME PUBLISHERS TO MERGE</a></li>
                                 <li><a href="../games/games_series_main.php" title="Game series" class="subbutton">GAME SERIES</a></li>
                                 <li><a href="../games/games_music.php" title="Game music" class="subbutton">GAME MUSIC</a></li>
                                 <li><a href="../games/submission_games.php" title="Game submissions" class="subbutton">GAME SUBMISSIONS</a></li>

--- a/Website/AtariLegend/themes/templates/1/main/games_detail_release_info.html
+++ b/Website/AtariLegend/themes/templates/1/main/games_detail_release_info.html
@@ -17,6 +17,21 @@
                             <br><br>
                         {/if}
 
+                        {if $release->getPublisher() != null}
+                            <span class="standard_tile_subtext">Publisher:</span>
+                            {$release->getPublisher()->getName()}
+                            <br>
+                        {/if}
+                        {if $release->getType()}
+                            <span class="standard_tile_subtext">Type:</span>
+                            {$release->getType()}
+                            <br>
+                        {/if}
+                        {if $release->getContinent() != null}
+                            <span class="standard_tile_subtext">Region:</span>
+                            {$release->getContinent()->getName()}
+                            <br>
+                        {/if}
                         {if $release_resolution[$release->getId()]}
                             <span class="standard_tile_subtext">Resolutions:</span>
                             {foreach from=$release_resolution[$release->getId()] item=resolution_id name=resolution}


### PR DESCRIPTION
- Updated DB `game_release` table to link to publishers, continent and
added a release type field
- Wrote DB update script to migrate games that have a single release and
a single publisher to the new structure
- Updated game editor and release editor screens accordingly
- Updated CPANEL autocomplete to support listing publishers
- Updated front end accordingly

Additionally, allow users to merge publishers associated directly to a
game to be merged in a release:
- Added a screen to list all the games that need merging
- Updated game editor screen to provide a link to merge a publisher with
a release
- Also allowing creating a new release instead, with the fields
pre-populated with the publisher ones.