### PR TITLE
Added a tab widget (#550) and applied it to the release editor

### DIFF
--- a/Sources/styles/1/scss/_cpanel-games.scss
+++ b/Sources/styles/1/scss/_cpanel-games.scss
@@ -310,3 +310,23 @@ ul.navigation-list {
 
     }
 }
+
+/* ------------------------------------------------------------
+* Release editor
+* ----------------------------------------------------------*/
+
+form.release_editor {
+    label.input {
+        font-weight: bold;
+        display: inline-block;
+        width: 230px;
+    }
+
+    .primary_button {
+        margin-left: 0;
+    }
+
+    .secondary_button {
+        padding-top: 4px;
+    }
+}

--- a/Sources/styles/1/scss/_general.scss
+++ b/Sources/styles/1/scss/_general.scss
@@ -609,14 +609,20 @@ $headerBackgroundcolor: #000000;
 //The CSS for the tabs
 //-------------------------------------------------------------*/
 //* Style the tab */
-div.tab {
+div.tab,
+ul.tabs {
     overflow: hidden;
     border: 1px solid #00d3d3;
     background-color: #00d3d3;
 }
 
+ul.tabs {
+    list-style-type: none;
+}
+
 //* Style the buttons inside the tab */
-div.tab button {
+div.tab button,
+ul.tabs li {
     background-color: #00d3d3;
     float: left;
     border: none;
@@ -626,20 +632,40 @@ div.tab button {
     transition: .3s;
 }
 
+ul.tabs li a {
+    color: #000 !important;
+}
+
 //* Change background color of buttons on hover */
-div.tab button:hover {
+div.tab button:hover,
+ul.tabs li:hover {
     background-color: #006f6f;
 }
 
 //* Create an active/current tablink class */
-div.tab button.active {
+div.tab button.active,
+ul.tabs li.active {
     background-color: #0d2e2e;
     color: #ffffff;
+}
+
+ul.tabs li.active a {
+    color: #fff !important;
 }
 
 //* Style the tab content */
 .tabcontent {
     display: none;
+}
+
+.tabcontent.active {
+    display: block;
+}
+
+.tabpane {
+    padding: 20px;
+    border: dotted 1px transparentize(#00d3d3, .5);
+    border-top: none;
 }
 
 //*fade in effect on tab */

--- a/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
@@ -7,9 +7,11 @@
 
 {block name=additional_scripts}
     <script src="{$template_dir}includes/js/ui.widgets.js"></script><!-- The autocomplete and dropdown switcher -->
+    <script src="{$template_dir}includes/js/ui.tabs.js"></script>
     <script>
         $(document).ready(function () {
             $('select[name=pub_dev_id]').altAutocomplete();
+            $('.tabs').tabs();
         });
     </script>
 {/block}
@@ -31,7 +33,7 @@
 
     <div class="standard_tile_line"></div>
 
-    <form method="POST">
+    <form method="POST" class="release_editor">
         <input type="hidden" name="game_id" value="{$game->getId()}">
         <input type="hidden" name="release_id" value="{$release->getId()}">
         <div class="standard_tile_padding">
@@ -44,108 +46,126 @@
                 </div>
                 <br>
 
-                <b>Release date</b>
-                {html_select_date time=$release->getDate() year_empty="Unknown" start_year=1984 display_days=0 display_months=0 class="standard_select"}
-                <br>
 
-                <b>Alternative title (optional)</b>
-                <input type="text" name="name" class="standard_input input_large" value="{$release->getName()}">
-                <br>
-                <span class="help-hint">e.g.: Translated title if it's a country-specific release. Leave blank if the title is the same as the game.</span>
-                <br>
-                <br>
+                <ul class="tabs">
+                    <li class="active"><a href="#tab-general">GENERAL</a></li>
+                    <li><a href="#tab-compatibility">COMPATIBILITY</a></li>
+                </ul>
 
-                <b>License</b>
-                <select name="license" class="standard_select select_large">
-                    {foreach from=$license_types item=type}
-                        <option {if $type == $release->getLicense()}selected{/if}>{$type}</option>
-                    {/foreach}
-                </select>
-                <br>
+                <div id="tab-general" class="tabcontent tabpane active">
 
-                <b>Type</b>
-                <select name="type" class="standard_select select_large">
-                    <option value="">-</option>
-                    {foreach from=$release_types item=release_type}
-                        <option {if $release_type == $release->getType() or (isset($type) and $type == $release_type)}selected{/if}>{$release_type}</option>
-                    {/foreach}
-                </select>
-                <br>
+                    <label class="input">Release date</label>
+                    {html_select_date time=$release->getDate() year_empty="Unknown" start_year=1984 display_days=0 display_months=0 class="standard_select"}
+                    <br>
 
-                <b>Continent</b>
-                <select name="continent_id" class="standard_select select_large">
-                    <option value="">-</option>
-                    {foreach from=$continents item=continent}
-                        <option value="{$continent->getId()}" {if ($release->getContinent() != null and $continent->getId() == $release->getContinent()->getId()) or (isset($continent_id) and $continent_id == $continent->getId())}selected{/if}>{$continent->getName()}</option>
-                    {/foreach}
-                </select>
-                <br>
+                    <label class="input">Alternative title (optional)</label>
+                    <input type="text" name="name" class="standard_input input_large" value="{$release->getName()}">
+                    <br>
+                    <span class="help-hint">e.g.: Translated title if it's a country-specific release. Leave blank if the title is the same as the game.</span>
+                    <br>
+                    <br>
 
-                <b>Publisher</b>
-                <a href="javascript:;"
-                    class="left_nav_link"
-                    id="pubdev_select_toggle"
-                    title="Click for dropdown mode">
-                    <i class="fa fa-fw fa-chevron-circle-down" aria-hidden="true"></i>
-                </a>
+                    <label class="input">License</label>
+                    <select name="license" class="standard_select select_large">
+                        {foreach from=$license_types item=type}
+                            <option {if $type == $release->getLicense()}selected{/if}>{$type}</option>
+                        {/foreach}
+                    </select>
+                    <br>
 
-                <select name="pub_dev_id"
-                    class="standard_select select_large"
-                    data-alt-autocomplete-endpoint="../common/autocomplete.php?extraParams=pub_dev"
-                    data-alt-autocomplete-toggle="#pubdev_select_toggle"
-                    data-alt-autocomplete-placeholder="Start typing a publisher name…">
-                    <option value="">-</option>
-                    {foreach from=$publishers item=publisher}
-                        <option value="{$publisher->getId()}" {if ($release->getPublisher() != null and $publisher->getId() == $release->getPublisher()->getId()) or (isset($pub_dev_id) and $pub_dev_id == $publisher->getId())}selected{/if}>{$publisher->getName()}</option>
-                    {/foreach}
-                </select>
+                    <label class="input">Type</label>
+                    <select name="type" class="standard_select select_large">
+                        <option value="">-</option>
+                        {foreach from=$release_types item=release_type}
+                            <option {if $release_type == $release->getType() or (isset($type) and $type == $release_type)}selected{/if}>{$release_type}</option>
+                        {/foreach}
+                    </select>
+                    <br>
 
-                <br><br>
+                    <label class="input">Continent</label>
+                    <select name="continent_id" class="standard_select select_large">
+                        <option value="">-</option>
+                        {foreach from=$continents item=continent}
+                            <option value="{$continent->getId()}" {if ($release->getContinent() != null and $continent->getId() == $release->getContinent()->getId()) or (isset($continent_id) and $continent_id == $continent->getId())}selected{/if}>{$continent->getName()}</option>
+                        {/foreach}
+                    </select>
+                    <br>
 
-                <h4>Screen resolution:</h4>
-                {foreach from=$resolutions item=resolution}
-                    <div class="checkbox links_mod_checkbox">
-                        <input type="checkbox"
-                            id="resolution_{$resolution->getId()}"
-                            name="resolution[]"
-                            {if in_array($resolution->getId(), $release_resolutions)}checked{/if}
-                            value="{$resolution->getId()}">
-                        <label for="resolution_{$resolution->getId()}"></label>
-                        &nbsp;{$resolution->getName()}<br>
-                    </div>
-                {/foreach}
-                <br>
+                    <label class="input">
+                        Publisher
+                        <a href="javascript:;"
+                            class="left_nav_link"
+                            id="pubdev_select_toggle"
+                            title="Click for dropdown mode">
+                            <i class="fa fa-fw fa-chevron-circle-down" aria-hidden="true"></i>
+                        </a>
+                    </label>
 
-                <h4>Enhanced for:</h4>
-                {foreach from=$systems item=system}
-                    {* Nothing is ever enhanced for the base ST *}
-                    {if $system->getName() != 'ST'}
+                    <select name="pub_dev_id"
+                        class="standard_select select_large"
+                        data-alt-autocomplete-endpoint="../common/autocomplete.php?extraParams=pub_dev"
+                        data-alt-autocomplete-toggle="#pubdev_select_toggle"
+                        data-alt-autocomplete-placeholder="Start typing a publisher name…">
+                        <option value="">-</option>
+                        {foreach from=$publishers item=publisher}
+                            <option value="{$publisher->getId()}" {if ($release->getPublisher() != null and $publisher->getId() == $release->getPublisher()->getId()) or (isset($pub_dev_id) and $pub_dev_id == $publisher->getId())}selected{/if}>{$publisher->getName()}</option>
+                        {/foreach}
+                    </select>
+
+                    <a href="javascript:;"
+                        onclick="javascript:$('select[name=pub_dev_id').val(''); $('#pub_dev_id-autocomplete-display').val('')"
+                        title="Click to remove publisher">
+                        &times;
+                    </a>
+
+                </div>
+
+                <div id="tab-compatibility" class="tabcontent tabpane">
+
+                    <label class="input">Screen resolution</label>
+                    {foreach from=$resolutions item=resolution}
                         <div class="checkbox links_mod_checkbox">
                             <input type="checkbox"
-                                id="system_enhanced_{$system->getId()}"
-                                name="system_enhanced[]"
-                                {if in_array($system->getId(), $system_enhanced)}checked{/if}
+                                id="resolution_{$resolution->getId()}"
+                                name="resolution[]"
+                                {if in_array($resolution->getId(), $release_resolutions)}checked{/if}
+                                value="{$resolution->getId()}">
+                            <label for="resolution_{$resolution->getId()}"></label>
+                            &nbsp;{$resolution->getName()}<br>
+                        </div>
+                    {/foreach}
+                    <br>
+
+                    <label class="input">Enhanced for</label>
+                    {foreach from=$systems item=system}
+                        {* Nothing is ever enhanced for the base ST *}
+                        {if $system->getName() != 'ST'}
+                            <div class="checkbox links_mod_checkbox">
+                                <input type="checkbox"
+                                    id="system_enhanced_{$system->getId()}"
+                                    name="system_enhanced[]"
+                                    {if in_array($system->getId(), $system_enhanced)}checked{/if}
+                                    value="{$system->getId()}">
+                                <label for="system_enhanced_{$system->getId()}"></label>
+                                &nbsp;{$system->getName()}<br>
+                            </div>
+                        {/if}
+                    {/foreach}
+                    <br>
+
+                    <label class="input">Incompatible with</label>
+                    {foreach from=$systems item=system}
+                        <div class="checkbox links_mod_checkbox">
+                            <input type="checkbox"
+                                id="system_incompatible_{$system->getId()}"
+                                name="system_incompatible[]"
+                                {if in_array($system->getId(), $system_incompatible)}checked{/if}
                                 value="{$system->getId()}">
-                            <label for="system_enhanced_{$system->getId()}"></label>
+                            <label for="system_incompatible_{$system->getId()}"></label>
                             &nbsp;{$system->getName()}<br>
                         </div>
-                    {/if}
-                {/foreach}
-                <br>
-
-                <h4>Incompatible with:</h4>
-                {foreach from=$systems item=system}
-                    <div class="checkbox links_mod_checkbox">
-                        <input type="checkbox"
-                            id="system_incompatible_{$system->getId()}"
-                            name="system_incompatible[]"
-                            {if in_array($system->getId(), $system_incompatible)}checked{/if}
-                            value="{$system->getId()}">
-                        <label for="system_incompatible_{$system->getId()}"></label>
-                        &nbsp;{$system->getName()}<br>
-                    </div>
-                {/foreach}
-                <br>
+                    {/foreach}
+                </div>
 
                 <button type="submit" name="submit_type" value="save_and_back" class="primary_button">Save and go back to '{$game->getName()}'</button>
                 <button type="submit" name="submit_type" value="save" class="secondary_button">Save changes</button>

--- a/Website/AtariLegend/themes/templates/1/includes/js/ui.tabs.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/ui.tabs.js
@@ -1,0 +1,35 @@
+(function ($) {
+    /**
+     * jQuery plugin to manage simple tabs */
+    $.fn.tabs = function () {
+        this.each(function () {
+            // Get the root of our tabs
+            var tabRoot = $(this),
+                // Get all our tab buttons
+                allTabButtons = tabRoot.find('li'),
+                // Get all the ID of the content panes
+                allTabsIds = allTabButtons.map(function () {
+                    return $(this).find('a').attr('href');
+                });
+
+            // Whenever a tab is clicked...
+            allTabButtons.click(function () {
+                // Remove the active class from all buttons
+                allTabButtons.removeClass('active');
+                // ...and set the one that was clicked on active
+                $(this).addClass('active');
+
+                // Then remove the active class from all content panes
+                $.each(allTabsIds, function (i, id) {
+                    $(id).removeClass('active');
+                });
+                // Find out the target content pane, and mark it active
+                var targetTabId = $(this).find('a').attr('href');
+                $(targetTabId).addClass('active');
+
+                // Prevent the click event on the anchor to be processed
+                return false;
+            });
+        });
+    }
+}(jQuery));


### PR DESCRIPTION
Added a simple tab widget to switch between content panes, and applied
it to the release editor to distinguish the general attributes from the
compatibility ones.