### PR TITLE
Fix skin switcher following removal of `rel` attribute

### DIFF
--- a/Website/AtariLegend/themes/templates/1/admin/main.html
+++ b/Website/AtariLegend/themes/templates/1/admin/main.html
@@ -204,10 +204,11 @@
                                         <li>
                                             <button class="sidebutton" id="skin_side">SKIN</button>
                                             <ul class="sub-menu">
-                                                <li><a href="#" class="sidebutton_cpanel">LEGACY</a></li>
-                                                <!--<li><a href="#" class="sidebutton_cpanel">TOS 2.07</a></li>
-                                                <li><a href="#" class="sidebutton_cpanel">PICASSO</a></li>-->
-                                            </ul>
+                                                <li><a href="#" data-skin="1" class="sidebutton_cpanel">LEGACY</a></li>
+                                                <!--
+                                                <li><a href="#" data-skin="2" class="sidebutton_cpanel">TOS 2.07</a></li>
+                                                <li><a href="#" data-skin="3" class="sidebutton_cpanel">PICASSO</a></li>                                            </ul>
+                                                -->
                                         </li>
                                     </ul>
                                 </nav>

--- a/Website/AtariLegend/themes/templates/1/includes/js/main.js
+++ b/Website/AtariLegend/themes/templates/1/includes/js/main.js
@@ -24,11 +24,11 @@ $(document).ready(function () {
 
     // Skin switcher
     $('.clearfix li a').click(function () {
-        var cssPath = '../../../themes/styles/' + $(this).attr('rel') + '/css/style.css';
-        var logoImgPath = '../../../themes/styles/' + $(this).attr('rel') + '/images/logos/top_logo01.png';
-        var logoImg480Path = '../../../themes/styles/' + $(this).attr('rel') + '/images/logos/top_logo01_480.png';
-        var logoBeePath = '../../../themes/styles/' + $(this).attr('rel') + '/images/top_right01.png';
-        var skin = $(this).attr('rel');
+        var skin = $(this).data('skin');
+        var cssPath = '../../../themes/styles/' + skin + '/css/style.css';
+        var logoImgPath = '../../../themes/styles/' + skin + '/images/logos/top_logo01.png';
+        var logoImg480Path = '../../../themes/styles/' + skin + '/images/logos/top_logo01_480.png';
+        var logoBeePath = '../../../themes/styles/' + skin + '/images/top_right01.png';
 
         $('link#main_stylesheet').attr('href', cssPath);
         $('#logo_img').attr('src', logoImgPath);

--- a/Website/AtariLegend/themes/templates/1/main/main.html
+++ b/Website/AtariLegend/themes/templates/1/main/main.html
@@ -116,9 +116,11 @@
                                         <li>
                                             <button class="sidebutton" id="skin_side">SKIN</button>
                                             <ul class="sub-menu">
-                                                <li><a href="#" class="sidebutton_cpanel">LEGACY</a></li>
-                                                <!--<li><a href="#" class="sidebutton_cpanel">TOS 2.07</a></li>
-                                                <li><a href="#" class="sidebutton_cpanel">PICASSO</a></li>-->
+                                                <li><a href="#" data-skin="1" class="sidebutton_cpanel">LEGACY</a></li>
+                                                <!--
+                                                <li><a href="#" data-skin="2" class="sidebutton_cpanel">TOS 2.07</a></li>
+                                                <li><a href="#" data-skin="3" class="sidebutton_cpanel">PICASSO</a></li>
+                                                -->
                                             </ul>
                                         </li>
                                     </ul>


### PR DESCRIPTION
The `rel` attribute was used to store the skin number. Use a `data-`
attribute instead to keep the HTML valid.