### PR TITLE
Fixes #567: Fixes front page slideshow

### DIFF
--- a/Sources/styles/common/main_scss/_tiles.scss
+++ b/Sources/styles/common/main_scss/_tiles.scss
@@ -189,10 +189,13 @@ figure.effect-tile:hover p.icon-links a:first-child {
 //*---------------------------------------************/
 
 figure.effect-bubba {
-    @if $skin_name == legacy {
-        background: rgb(0, 80, 80);
-    } @else if $skin_name == tos or $skin_name == picasso {
-        background: rgb(172, 172, 172);
+    background: transparent;
+    &:hover {
+        @if $skin_name == legacy {
+            background: rgba(0, 80, 80, .6);
+        } @else if $skin_name == tos or $skin_name == picasso {
+            background: rgba(172, 172, 172, .6);
+        }
     }
 }
 


### PR DESCRIPTION
It broke when jssor was upgraded.

I'm actually not sure how it worked before, because the `figure` that's
on top of the image didn't have a transparent background... So it's more
likely that the upgrade revealed a bug that was already there!

In any case, it works now.