### PR TITLE
Fix DB script to remove `game_release.memory_id`

### DIFF
--- a/Website/AtariLegend/php/admin/administration/database_scripts/241/addition.php
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/241/addition.php
@@ -1,4 +1,0 @@
-<?php
-/* SET FOREIGN_KEY_CHECKS=0;
-sql = "ALTER TABLE game_release DROP COLUMN memory_id;"
-SET FOREIGN_KEY_CHECKS=1; */

--- a/Website/AtariLegend/php/admin/administration/database_scripts/241/drop_memory_id_column.ini
+++ b/Website/AtariLegend/php/admin/administration/database_scripts/241/drop_memory_id_column.ini
@@ -1,8 +1,8 @@
-description = "Drop memory_id column from game_release - TO DO!!!!!!"
+description = "Drop memory_id column from game_release"
 execute_on = "success"
 condition = "SELECT *
-FROM information_schema.tables
-WHERE table_schema = '__DBNAME__'
-AND table_name = 'game_release'
-LIMIT 1
-"
+    FROM information_schema.columns
+    WHERE table_schema = '__DBNAME__'
+    AND table_name = 'game_release'
+    AND column_name = 'memory_id'"
+sql="ALTER TABLE game_release DROP FOREIGN KEY game_release_ibfk_4, DROP COLUMN memory_id"


### PR DESCRIPTION
The column is used in a foreign key constraint, so the constraint must
be deleted first.