### PR TITLE
Jumpstart to get dumps for a media

### DIFF
--- a/Website/AtariLegend/php/admin/games/games_release_detail.php
+++ b/Website/AtariLegend/php/admin/games/games_release_detail.php
@@ -62,12 +62,12 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
     $smarty->assign('enhancements', $enhancementDao->getAllEnhancements());
     $smarty->assign('media_types', $mediaTypeDao->getAllMediaTypes());
     $smarty->assign('dump_formats', $dumpDao->getFormats());
-    
+
     // Edit existing release
     if (isset($release_id)) {
         $release = $gameReleaseDao->getRelease($release_id);
         $game = $gameDao->getGame($release->getGameId());
-        
+
         $smarty->assign('game_screenshot', $gameDao->getRandomScreenshot($game->getId()));
 
         $smarty->assign('release', $release);
@@ -84,15 +84,24 @@ if ($_SERVER['REQUEST_METHOD'] == "GET") {
         $smarty->assign('release_akas', $gameReleaseAkaDao->getAllGameReleaseAkas($release->getId()));
         $smarty->assign('release_trainer_options', $trainerOptionDao->getTrainerOptionsForRelease($release->getId()));
         $smarty->assign('distributors', $pubDevDao->getAllPubDevs());
-        $smarty->assign('release_distributors', $pubDevDao->getDistributorsForRelease($release->getId()));   
+        $smarty->assign('release_distributors', $pubDevDao->getDistributorsForRelease($release->getId()));
         $smarty->assign('release_memory_enhancements', $memoryDao->getMemoryForRelease($release->getId()));
         $smarty->assign('release_minimum_memory', $memoryDao->getMinimumMemoryForRelease($release->getId()));
         $smarty->assign('release_memory_incompatible', $memoryDao->getMemoryIncompatibleForRelease($release->getId()));
         $smarty->assign('release_copy_protections', $copyProtectionDao->getCopyProtectionsForRelease($release->getId()));
         $smarty->assign('release_disk_protections', $diskProtectionDao->getDiskProtectionsForRelease($release->getId()));
         $smarty->assign('release_languages', $languageDao->getAllGameReleaseLanguages($release->getId()));
-        $smarty->assign('release_media', $mediaDao->getAllMediaFromRelease($release->getId()));
-        
+
+        $media = $mediaDao->getAllMediaFromRelease($release->getId());
+        $smarty->assign('release_media', $media);
+
+        $dumps = [];
+        foreach ($media as $medium) {
+            $dumps[$medium->getId()] = $dumpDao->getAllDumpsFromMedia($medium->getId());
+        }
+        $smarty->assign('dumps', $dumps);
+
+
     } else {
         // Creating a new release
         $game = $gameDao->getGame($game_id);

--- a/Website/AtariLegend/php/common/DAO/DumpDAO.php
+++ b/Website/AtariLegend/php/common/DAO/DumpDAO.php
@@ -10,7 +10,7 @@ require_once __DIR__."/../../vendor/pclzip/pclzip/pclzip.lib.php" ;
  */
 class DumpDAO {
     private $mysqli;
-    
+
     const FORMAT_STX = 'STX';
     const FORMAT_MSA = 'MSA';
     const FORMAT_RAW = 'RAW';
@@ -19,7 +19,7 @@ class DumpDAO {
     public function __construct($mysqli) {
         $this->mysqli = $mysqli;
     }
-    
+
     /**
      * Get all the formats
      * @return String[] A list of formats
@@ -32,7 +32,7 @@ class DumpDAO {
             DumpDAO::FORMAT_SCP
         );
     }
-    
+
      /**
      * Add a dump to a media
      *
@@ -51,7 +51,7 @@ class DumpDAO {
         $game_file_path,
         $filesize
     ) {
-        
+
         // Time for zip magic
         $zip = new \PclZip("$tempfilename");
 
@@ -77,26 +77,26 @@ class DumpDAO {
         } else {
             exit("Try uploading a diskimage type that is allowed, like stx or msa not $ext");
         }
-        
+
         //Compare the extension with the format
         //if ($ext == $format) {
         //} else {
         //    exit("The selected format is not the same as the uploaded file");
         //}
-        
+
         // create a timestamp for the date of upload
         $timestamp = time();
-        
+
         $stmt = \AL\Db\execute_query(
             "DumpDAO: addDumptoMedia",
             $this->mysqli,
             "INSERT INTO dump (`media_id`, `format`, `info`, `date`, `size` ) VALUES (?, ?, ?, ?, ?)",
             "issii", $media_id, $format, $info, $timestamp, $filesize
         );
-        
+
         //get the new dump id
         $new_dump_id = $this->mysqli->insert_id;
-        
+
         // Time to unzip the file to the temporary directory
         $archive = new \PclZip("$tempfilename");
 
@@ -119,23 +119,23 @@ class DumpDAO {
         // the database, this will be used in the download function to check everytime the file
         // is being downloaded... if the hashes don't match, then datacorruption have changed the file.
         $crc = openssl_digest("$game_file_path$new_dump_id.zip", 'sha512');
-        
+
         $stmt = \AL\Db\execute_query(
             "DumpDAO: addDumptoMedia",
             $this->mysqli,
             "UPDATE dump SET sha512 = ? WHERE id = ?",
             "si", $crc, $new_dump_id
         );
-        
+
         // Chmod file so that we can backup/delete files through ftp.
         chmod("$game_file_path$new_dump_id.zip", 0777);
 
         // Delete the unzipped file in the temporary directory
         unlink("$game_file_temp_path$new_dump_id.$ext");
-        
+
         $stmt->close();
     }
-    
+
     /**
      * Get all dumps from media
      *
@@ -145,7 +145,7 @@ class DumpDAO {
         $stmt = \AL\Db\execute_query(
             "DumpDAO: getAllDumpsFromMedia",
             $this->mysqli,
-            "SELECT id, format, date, size, info FROM dump
+            "SELECT id, format, sha512, date, size, info FROM dump
             WHERE media_id = ?",
             "i", $media_id
         );
@@ -153,13 +153,13 @@ class DumpDAO {
         \AL\Db\bind_result(
             "DumpDAO: getAllDumpsFromMedia",
             $stmt,
-            $media_id
+            $id, $format, $sha512, $date, $size, $info
         );
 
         $dump = [];
         while ($stmt->fetch()) {
             $dump[] = new \AL\Common\Model\Dump\Dump(
-                $id, null, $format, null, $date, $size, $info
+                $id, $media_id, $format, $sha512, $date, $size, $info
             );
         }
 

--- a/Website/AtariLegend/php/common/DAO/EmulatorDAO.php
+++ b/Website/AtariLegend/php/common/DAO/EmulatorDAO.php
@@ -89,8 +89,8 @@ class EmulatorDAO {
 
         return $emulators;
     }
-    
-        
+
+
      /**
      * Get all emulator IDs incompatible with a release
      *
@@ -102,7 +102,7 @@ class EmulatorDAO {
             "EmulatorDAO: getIncompatibleEmulatorsForRelease",
             $this->mysqli,
             "SELECT game_release_emulator_incompatibility.emulator_id,
-                    emulator.name FROM game_release_emulator_incompatibility 
+                    emulator.name FROM game_release_emulator_incompatibility
                     LEFT JOIN emulator ON (game_release_emulator_incompatibility.emulator_id = emulator.id)
                     WHERE release_id = ?",
             "i", $release_id
@@ -149,7 +149,7 @@ class EmulatorDAO {
 
         $stmt->close();
     }
-    
+
         /**
      * add a emulator to the database
      *
@@ -165,7 +165,7 @@ class EmulatorDAO {
 
         $stmt->close();
     }
-    
+
     /**
      * delete a emulator
      *
@@ -181,7 +181,7 @@ class EmulatorDAO {
 
         $stmt->close();
     }
-    
+
         /**
      * update a emulator
      *
@@ -195,7 +195,7 @@ class EmulatorDAO {
             "UPDATE emulator SET name = ? WHERE id = ?",
             "si", $emulator_name, $emulator_id
         );
-        
+
         $stmt->close();
     }
 }

--- a/Website/AtariLegend/php/common/Model/Dump/Dump.php
+++ b/Website/AtariLegend/php/common/Model/Dump/Dump.php
@@ -8,15 +8,15 @@ class Dump {
     private $id;
     private $media_id;
     private $format;
-    private $hash;
+    private $sha512;
     private $date;
     private $size;
     private $info;
 
-    public function __construct($id, $media_id, $format, $hash, $date, $size, $info) {
+    public function __construct($id, $media_id, $format, $sha512, $date, $size, $info) {
         $this->id = $id;
         $this->format = $format;
-        $this->hash = $hash;
+        $this->sha512 = $sha512;
         $this->date = $date;
         $this->size = $size;
         $this->info = $info;
@@ -25,27 +25,27 @@ class Dump {
     public function getId() {
         return $this->id;
     }
-    
+
     public function getMediaId() {
         return $this->media_id;
     }
-   
+
     public function getFormat() {
         return $this->format;
     }
-    
-    public function getHash() {
-        return $this->hash;
+
+    public function getSha512() {
+        return $this->sha512;
     }
-    
+
     public function getDate() {
         return $this->date;
     }
-    
+
     public function getSize() {
         return $this->size;
     }
-    
+
     public function getInfo() {
         return $this->info;
     }

--- a/Website/AtariLegend/php/common/Model/Dump/Media.php
+++ b/Website/AtariLegend/php/common/Model/Dump/Media.php
@@ -16,7 +16,7 @@ class Media {
     public function getId() {
         return $this->id;
     }
-   
+
     public function getMediaType() {
         return $this->media_type;
     }

--- a/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
+++ b/Website/AtariLegend/themes/templates/1/admin/games_release_detail.html
@@ -788,6 +788,7 @@
                                     href="../games/db_games_release_detail.php?game_id={$game->getId()}&amp;release_id={$release->getId()}&amp;media_id={$linked_media->getId()}&amp;action=remove_media"
                                     onclick="javascript:return confirm('This media record will be removed from the release')">
                                     <span class="fa fa-fw fa-trash"></span>
+
                                 </a>
                                 <input type="hidden" name="game_id" value="{$game->getId()}">
                                 <input type="hidden" name="release_id" value="{$release->getId()}">
@@ -828,6 +829,11 @@
                                     This is a test for scans
                                 </div>
                             </form>
+                            <ul>
+                                {foreach from=$dumps[$linked_media->getId()] item=dump}
+                                    <li>{$dump->getId()} {$dump->getFormat()} {$dump->getSha512()} {$dump->getSize()}</li>
+                                {/foreach}
+                            </ul>
                         {/foreach}
                     {/if}
                     <hr class="separator_add">


### PR DESCRIPTION
Each media can have multiple dump, so we need to have an association
between a media and its dump. I chose to use an associative array for
this, where the key is the `media_id`, and the values are the Dump
objects.

In the template, just retrieve the dumps for the specific ID from the
associative array, and loop over it.

Aside: I renamed the Hash property Sha512 to be consistent with the
database name column.