### PR TITLE
Attempt to fix auto-deploy again

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# -
+# Script to deploy the code to the dev server via rsync
+set -e
+
+# BRANCH is the current branch, but for pull requests will contain the
+# name of the *target* branch!
+echo "Current BRANCH: ${BRANCH}"
+# HEAD_BRANCH is set only on merge requests and contains the name of the
+# source branch
+echo "Current HEAD_BRANCH: ${HEAD_BRANCH}"
+
+# We want to deploy only when the dev branch is built, outside of a
+# pull request
+if [ -z "${HEAD_BRANCH}" ] && [ "${BRANCH}" == "development" ]; then
+    rsync -azv Website/AtariLegend/* $DEV_DEPLOY_USER@$DEV_DEPLOY_HOST:$DEV_DEPLOY_PATH/
+fi

--- a/shippable.yml
+++ b/shippable.yml
@@ -25,5 +25,4 @@ build:
     # If the build succeeded and we're on the development branch,
     # sync all the file to the dev server
     on_success:
-        - test ${BRANCH} = "development" || return 0
-        - rsync -azv Website/AtariLegend/* $DEV_DEPLOY_USER@$DEV_DEPLOY_HOST:$DEV_DEPLOY_PATH/
+        - ./deploy.sh


### PR DESCRIPTION
The `BRANCH` value will vary depending if the build is done as part of a
pull request or not. If it is, it will contain the name of the target
branch, which will be `development`, and will trigger a deploy...

Look also at `HEAD_BRANCH` which contains the name of the source branch
on pull requests

Also moved the logic into a script, because Shippable doesn't support
testing values within the YAML file very well: If the test exists with a
non-zero code this is considered an error, and attempting to chain it
with `|| exit 0` doesn't work and fail the build too