### PR TITLE
Fixes #671: Restore styles for button based tabs

### DIFF
--- a/Sources/styles/1/scss/_general.scss
+++ b/Sources/styles/1/scss/_general.scss
@@ -655,6 +655,12 @@ ul.tabs li {
     }
 }
 
+div.tab button.tablinks {
+    display: block;
+    padding: 14px 16px;
+    cursor: pointer;
+}
+
 //* Change background color of buttons on hover */
 div.tab button:hover,
 ul.tabs li:hover,


### PR DESCRIPTION
I tweaked the CSS when I was working on the tabs for releases and that
broke other pages that were doing tabs differently (buttons instead of
links). This should restore it.