### PR TITLE
Run the DB upgrade script after syncing the files to DEV

### DIFF
--- a/Website/AtariLegend/php/config/admin.php
+++ b/Website/AtariLegend/php/config/admin.php
@@ -15,8 +15,11 @@
 //But I did not want to include this file in every single page, so I placed the include here.
 include("../../common/tiles/tile_bug_report.php");
 
-//This is the actual authorization check
-if (login_check($mysqli) == false) {
+// This is the actual authorization check
+
+// We allow scripts running on the command line to run so that we can run the
+// DB upgrade script when we auto-deploy on DEV
+if (php_sapi_name() !== "cli" && login_check($mysqli) == false) {
     $_SESSION['edit_message'] = "Please log in to use this functionality";
     if (isset($_SERVER['HTTP_REFERER'])) {
         header('Location: ' . $_SERVER['HTTP_REFERER']);

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,4 +16,7 @@ if [ -z "${HEAD_BRANCH}" ] && [ "${BRANCH}" == "development" ]; then
     # Exclude data/ and the connection settings file as we don't want
     # them to be deleted on the remote server
     rsync -avz --exclude data --exclude php/config/connection_settings.php --delete Website/AtariLegend/* $DEV_DEPLOY_USER@$DEV_DEPLOY_HOST:$DEV_DEPLOY_PATH/
+
+    # Run the DB upgrade script via the PHP command-line interface
+    ssh $DEV_DEPLOY_USER@$DEV_DEPLOY_HOST "cd $DEV_DEPLOY_PATH/php/admin/administration/ && php7.1-cli database_update.php"
 fi


### PR DESCRIPTION
Use the PHP command-line interface to run the script remotely (via SSH).

It's a bit messy as there are warnings because a lot of the code expects
to be run in a web environment rather than via the command-line, but it
does the job.

I had to use the PHP 7.1 CLI as 1and1 only has v5.5 or v7.1, but not 5.6
(which is the version we use on the site). v5.5 didn't work.