### PR TITLE
For #726: Media tile - Use similar layout to CPANEL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "**/temp/**": true,
+        "node_modules": true
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,3 @@ $db_username = "YOUR_DB_USER_NAME";
 $db_password = "YOUR_DB_PASSWORD";
 $db_databasename = "YOUR_DB_NAME";
 ```
-=======
-Atarilegend is a website for Atari ST enthousiasts and retro gamers in general. The site has been up since 2004, but was abandonned around 2009. It is time for an update/upgrade ;-)
-

--- a/Sources/styles/1/scss/al/common/_common.scss
+++ b/Sources/styles/1/scss/al/common/_common.scss
@@ -9,3 +9,8 @@ a.al-inverse {
         color: white;
     }
 }
+
+h1, h2 {
+    margin-top: .75rem;
+    margin-bottom: .25rem;
+}

--- a/Sources/styles/1/scss/al/common/_table.scss
+++ b/Sources/styles/1/scss/al/common/_table.scss
@@ -1,0 +1,13 @@
+table.al-table {
+    width: 100%;
+    border-spacing: 0;
+
+    th {
+        text-align: left;
+    }
+
+    td {
+        border-top: solid 1px $brand_primary_dimmed;
+        padding: 0.25rem;
+    }
+}

--- a/Sources/styles/1/scss/al/main/_games.scss
+++ b/Sources/styles/1/scss/al/main/_games.scss
@@ -219,11 +219,13 @@
         }
     }
 
-    .al-release-media-scan {
-        width: 10rem;
+    .al-release-media-scans {
+        display: inline-block;
 
         img {
-            width: 100%;
+            display: inline;
+            width: 5rem;
+            margin-right: 0.25rem;
             margin-bottom: 0.25rem;
             border: solid 1px $brand_primary_dimmed;
         }

--- a/Sources/styles/1/scss/style.scss
+++ b/Sources/styles/1/scss/style.scss
@@ -112,6 +112,7 @@ $sizes: (
 @import 'al/common/utilities';
 @import 'al/common/tile';
 @import 'al/common/common';
+@import 'al/common/table';
 @import 'al/main/games';
 
 //*----------------------------------------------------------

--- a/Website/AtariLegend/php/admin/games/games_facts.php
+++ b/Website/AtariLegend/php/admin/games/games_facts.php
@@ -44,7 +44,6 @@ while ($sql_games_facts = $query_games_facts->fetch_array(MYSQLI_BOTH)) {
         $new_path .= $sql_screenshots_facts['imgext'];
 
         $smarty->append(
-
             'facts_screenshots',
             array('game_fact_id' => $sql_games_facts['game_fact_id'],
                'screenshot_id' => $sql_screenshots_facts['screenshot_id'],

--- a/Website/AtariLegend/php/common/tiles/latest_comments_tile.php
+++ b/Website/AtariLegend/php/common/tiles/latest_comments_tile.php
@@ -57,7 +57,6 @@ while ($query_comment = $sql_comment->fetch_array(MYSQLI_BOTH)) {
     $date = date("d/m/y", $query_comment['timestamp']);
 
     $smarty->append(
-
         'comments',
         array('comment' => $oldcomment,
               'comment_edit' => $comment,

--- a/Website/AtariLegend/php/common/tiles/latest_interviews_tile.php
+++ b/Website/AtariLegend/php/common/tiles/latest_interviews_tile.php
@@ -35,7 +35,6 @@ while ($sql_recent_interviews = $sql_interview->fetch_array(MYSQLI_BOTH)) {
     $v_interview_date = date("F j, Y", $sql_recent_interviews['interview_date']);
 
     $smarty->append(
-
         'recent_interviews',
         array( 'individual_name' => $sql_recent_interviews['ind_name'],
                 'individual_id' => $sql_recent_interviews['ind_id'],

--- a/Website/AtariLegend/php/common/tiles/latest_reviews_tile.php
+++ b/Website/AtariLegend/php/common/tiles/latest_reviews_tile.php
@@ -70,7 +70,6 @@ while ($sql_recent_reviews = $query_recent_reviews->fetch_array(MYSQLI_BOTH)) {
     $review_date = date("F j, Y", $sql_recent_reviews['review_date']);
 
     $smarty->append(
-
         'recent_reviews',
         array('review_name' => $sql_recent_reviews['game_name'],
            'review_id' => $sql_recent_reviews['review_id'],

--- a/Website/AtariLegend/php/common/tiles/screenstar.php
+++ b/Website/AtariLegend/php/common/tiles/screenstar.php
@@ -66,7 +66,6 @@ $sql_screenstar = $query_screenstar->fetch_array(MYSQLI_BOTH);
     $screenstar_image .= $sql_screenstar['imgext'];
 
     $smarty->assign(
-
         'screenstar',
         array('screenstar_game_name' => $sql_screenstar['game_name'],
            'screenstar_review' => $screenstar_review,

--- a/Website/AtariLegend/php/common/tiles/tile_bug_report.php
+++ b/Website/AtariLegend/php/common/tiles/tile_bug_report.php
@@ -19,7 +19,6 @@ $query_bug_report_type = $mysqli->query("SELECT * FROM bug_report_type") or die(
 
 while ($sql_bug_report_type = $query_bug_report_type->fetch_array(MYSQLI_BOTH)) {
     $smarty->append(
-
         'bug_report_type',
         array('bug_report_type_id' => $sql_bug_report_type['bug_report_type_id'],
                    'bug_report_type' => $sql_bug_report_type['bug_report_type'])

--- a/Website/AtariLegend/php/common/tiles/who_is_it_tile.php
+++ b/Website/AtariLegend/php/common/tiles/who_is_it_tile.php
@@ -54,7 +54,6 @@ $int_text = trim($int_text);
 $int_text = RemoveSmillies($int_text);
 
 $smarty->assign(
-
     'who_is_it',
     array('ind_id' => $sql_interview['ind_id'],
                'ind_name' => $sql_interview['ind_name'],

--- a/Website/AtariLegend/themes/templates/1/main/games/games_release_main.html
+++ b/Website/AtariLegend/themes/templates/1/main/games/games_release_main.html
@@ -5,7 +5,12 @@
 {/strip}{/block}
 {block name=description}{$release_description}{/block}
 
+{block name=additional_css}
+    <link type="text/css" href="{$style_dir}css/vendor/lightbox-2.9.0.css" hreflang="en" rel="stylesheet">
+{/block}
+
 {block name=additional_scripts}
+    <script src="{$template_dir}includes/js/vendor/lightbox-2.9.0.min.js"></script>
     <script src="{$template_dir}includes/js/ui.tabs.js"></script>
     <script>
         jQuery(document).ready( function() {

--- a/Website/AtariLegend/themes/templates/1/main/games/tiles/tile_game_release_media.html
+++ b/Website/AtariLegend/themes/templates/1/main/games/tiles/tile_game_release_media.html
@@ -6,69 +6,67 @@
         {if count($medias) > 0}
 
             <div class="al-row">
-                <div class="al-column al-m-0">
-                    <ul class="al-list-unstyled al-p-0 al-tab">
-                        {foreach from=$medias item=media name=media}
-                            {strip}
-                                <li {if $smarty.foreach.media.first}class="active"{/if}>
-                                    <a href="#al-release-media-{$media->getId()}">
-                                        {$media->getMediaType()->getName()}
-                                        {if $media->getLabel() != null}
-                                            &nbsp;<span class="al-text-muted">({$media->getLabel()})</span>
-                                        {/if}
-                                    </a>
-                                </li>
-                            {/strip}
-                        {/foreach}
-                    </ul>
-                </div>
+                <div class="al-column">
+                    {foreach from=$medias item=media name=media}
+                        <h2>{$media->getMediaType()->getName()}
+                        {if $media->getLabel() != null}
+                            <small class="al-text-muted">({$media->getLabel()})</small>
+                        {/if}
+                        </h2>
 
-                <div class="al-column-3 al-tab-pane al-p-1">
-                    <small style="color: red">TODO: Count downloads</small><br>
-                    {foreach from=$medias item=media name="media"}
-                        <div class="al-release-media {if $smarty.foreach.media.first}active{/if}" id="al-release-media-{$media->getId()}">
-                            <div class="al-release-media-scans">
-                                {foreach from=$media_scans[$media->getId()] item=scan}
-                                    <div class="al-release-media-scan al-text-center al-text-muted al-fontsize-small">
-                                        <img class="al-release-media-scan" alt="{$scan->getMediaScanType()->getName()}" src="{$media_scans_path}{$scan->getId()}.{$scan->getImage()}">
-                                        {$scan->getMediaScanType()->getName()}
-                                    </div>
-                                {/foreach}
-                            </div>
-
-                            <div>
-                                {if $dumps[$media->getId()] != null}
-                                    <h2>{count($dumps[$media->getId()])} dump{if count($dumps[$media->getId()]) > 1}s{/if}:</h2>
-                                    <ul class="al-list-unstyled">
-                                        {foreach from=$dumps[$media->getId()] item=dump}
-                                            <li>
-                                                {$dump->getFormat()}
-                                                <span class="al-text-muted">uploaded by</span> {$dump->getUser()->getName()}
-                                                <span class="al-text-muted">
-                                                    {$dump->getDate()|timeago}
-                                                    ({math equation="floor(x/y)" x=$dump->getSize() y=1024} KB)
-                                                </span>
-                                                {if isset($user_session)}
-                                                    <a href="../../../data/zips/games/{$dump->getId()}.zip"><i class="fa fa-download" aria-hidden="true"></i></a>
-                                                {else}
-                                                    <span class="al-not-logged-in">Please log in to download</span>
-                                                {/if}
-                                                <br>
-                                                <abbr title="SHA512: {$dump->getSha512()}">{$dump->getSha512()|truncate:8:""}</abbr>
-
-                                                <em class="al-text-muted">{$dump->getInfo()}</em>
-
-                                            </li>
-                                        {/foreach}
-                                    </ul>
-                                {else}
-                                    No dumps to download for this media
-                                {/if}
-                            </div>
+                        {if count($media_scans[$media->getId()]) gt 0}
+                        <div class="al-release-media-scans">
+                            {foreach from=$media_scans[$media->getId()] item=scan}
+                                <a href="{$media_scans_path}{$scan->getId()}.{$scan->getImage()}"
+                                    data-lightbox="image-{$scan->getId()}">
+                                    <img class="al-release-media-scan"
+                                        alt="{$scan->getMediaScanType()->getName()}"
+                                        src="{$media_scans_path}{$scan->getId()}.{$scan->getImage()}">
+                                </a>
+                            {/foreach}
                         </div>
+                        {/if}
+
+                        {if $dumps[$media->getId()] != null}
+                            <table class="al-table">
+                                <thead>
+                                    <tr>
+                                        <th>Format</th>
+                                        <th>Added</th>
+                                        <th>By</th>
+                                        <th>Notes</th>
+                                        <th>Size</th>
+                                        <th>sha512</th>
+                                        <th></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                {foreach from=$dumps[$media->getId()] item=dump}
+                                    <tr>
+                                        <td>{$dump->getFormat()}</td>
+                                        <td>{$dump->getDate()|timeago}</td>
+                                        <td>{$dump->getUser()->getName()}</td>
+                                        <td>{$dump->getInfo()|default:'-'}</td>
+                                        <td>{math equation="floor(x/y)" x=$dump->getSize() y=1024} KB</td>
+                                        <td><abbr title="SHA512: {$dump->getSha512()}">{$dump->getSha512()|truncate:8:""}</abbr></td>
+                                        <td>
+                                            {if isset($user_session)}
+                                                <a href="../../../data/zips/games/{$dump->getId()}.zip"><i class="fa fa-download" aria-hidden="true"></i></a>
+                                            {else}
+                                                <span class="al-not-logged-in">Please log in to download</span>
+                                            {/if}
+                                        </td>
+                                    </tr>
+                                {/foreach}
+                                </tbody>
+                            </table>
+                        {else}
+                            <p>No dump for this media.</p>
+                        {/if}
                     {/foreach}
                 </div>
             </div>
+
         {else}
             <p class="al-text-center">
                 No media dumps or media scans for this release.


### PR DESCRIPTION
Updated the media tile to look a bit more like the CPANEL, where the
dumps are presented in a table.

It's not super pretty and it doesn't work well on mobile yet, but that's
a start.

Aside:
- Fixed README
- Added VSCode config folder
- Fix a few PHPCS issues