### PR TITLE
Update pclzip.lib.php

### DIFF
--- a/Website/AtariLegend/php/vendor/pclzip/pclzip/pclzip.lib.php
+++ b/Website/AtariLegend/php/vendor/pclzip/pclzip/pclzip.lib.php
@@ -187,7 +187,7 @@
   //   extract() : Extract the content of the archive
   //   properties() : List the properties of the archive
   // --------------------------------------------------------------------------------
-  class PclZip
+  class PclZi
   {
     // ----- Filename of the zip file
     var $zipname = '';


### PR DESCRIPTION
rename class 'PclZip' into 'PclZi' to avoid error message when adding/editing a game release.