### PR TITLE
Cleanup email handling

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -12,6 +12,8 @@ RSYNC_FLAGS=(
     # Exclude the connection settings file from being deleted, as it's
     # not in Git
     --exclude php/config/connection_settings.php
+    # Exclude the email settings file from being deleted, as it's not in Git
+    -- exclude php/config/email_settings.php
     # Exclude _elite folder, not in Git
     --exclude _elite
     # Exclude _stonish folder, not in Git

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ Website/AtariLegend/data/database-dumps/*.sql.gz
 
 # exclude the database connection settings file
 /Website/AtariLegend/php/config/connection_settings.php
+# exclude the SMTP settings file
+/Website/AtariLegend/php/config/email_settings.php
 
 # exclude the SASS cache
 /Website/AtariLegend/themes/.sass-cache/

--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@ $db_username = "YOUR_DB_USER_NAME";
 $db_password = "YOUR_DB_PASSWORD";
 $db_databasename = "YOUR_DB_NAME";
 ```
+
+* Create a PHP file containing the SMTP settings in `Website/AtariLegend/php/config/email_settings.php`:
+
+```php
+<?php
+
+$email_mailer = 'smtp';   // See PHPMailer for possible values
+$smtp_username = '...';
+$smtp_password = '...';
+$smtp_port = 587;
+$smtp_host = '...';
+$smtp_auth = true;
+$smtp_secure = 'ssl';
+```

--- a/Website/AtariLegend/php/admin/user/db_user_management.php
+++ b/Website/AtariLegend/php/admin/user/db_user_management.php
@@ -62,7 +62,7 @@ if (isset($action) and $action == "delete_user") {
 
 if (isset($action) and $action == "email_user") {
     if (isset($user_id)) {
-        $mail = new PHPMailer;
+        $mail = new PHPMailer(true);
 
         $start = microtime(true);
         $i     = 0;
@@ -82,15 +82,13 @@ if (isset($action) and $action == "email_user") {
         //$mail->SMTPDebug  = 2;                            // enables SMTP debug information (for testing)
         // 1 = errors and messages
         // 2 = messages only
-        //$mail->Host = 'smtp.live.com';                    // Specify main and backup SMTP servers
-        $mail->Host       = $ms_host;
-        $mail->SMTPAuth   = true; // Enable SMTP authentication
-        $mail->Username   = $ms_usn;
-        $mail->Password   = $ms_pwd;
-        $mail->SMTPSecure = 'tls'; // Enable TLS encryption, `ssl` also accepted
-        //$mail->SMTPSecure = 'ssl';
-        //$mail->Port = 587;                                // TCP port to connect to
-        $mail->Port       = $ms_port;
+        $mail->Mailer     = $email_mailer;
+        $mail->Host       = $smtp_host;
+        $mail->SMTPAuth   = $smtp_auth;
+        $mail->Username   = $smtp_username;
+        $mail->Password   = $smtp_password;
+        $mail->SMTPSecure = $smtp_secure;
+        $mail->Port       = $smtp_port;
 
         $mail->setFrom($pwd_reset_from, 'Atarilegend');
         $mail->addReplyTo($pwd_reset_reply, 'Atarilegend');

--- a/Website/AtariLegend/php/common/login/db_register.php
+++ b/Website/AtariLegend/php/common/login/db_register.php
@@ -119,7 +119,7 @@ if (isset($action) and $action == 'confirm') {
                                 // Create a url which we will direct them to reset their password
                                 $pwrurl = $confirm_account_link.'&pwd='.$md5pass.'&usn='.$user_name;
 
-                                $mail = new PHPMailer;
+                                $mail = new PHPMailer(true);
 
                                 $start = microtime(true);
                                 $i     = 0;
@@ -132,20 +132,17 @@ if (isset($action) and $action == 'confirm') {
                                 // on localhost it runs with this command $mail->isSMTP();
                                 // Set mailer to use SMTP
 
-                                $mail->SMTPDebug  = 0;  // enables SMTP debug information (for testing)
+                                // $mail->SMTPDebug  = 0;  // enables SMTP debug information (for testing)
                                 // 1 = errors and messages
                                 // 2 = messages only
                                 //$mail->Host = 'smtp.live.com'; // Specify main and backup SMTP servers
-                                $mail->Host       = $ms_host;
-                                $mail->SMTPAuth   = true; // Enable SMTP authentication
-                                //$mail->Username = 'atarilegend@hotmail.com';      // SMTP username
-                                //$mail->Password = '@Tar1L3geNd';                  // SMTP password
-                                $mail->Username   = $ms_usn;
-                                $mail->Password   = $ms_pwd;
-                                $mail->SMTPSecure = 'tls'; // Enable TLS encryption, `ssl` also accepted
-                                //$mail->SMTPSecure = 'ssl';
-                                //$mail->Port = 587;       // TCP port to connect to
-                                $mail->Port       = $ms_port;
+                                $mail->Mailer     = $email_mailer;
+                                $mail->Host       = $smtp_host;
+                                $mail->SMTPAuth   = $smtp_auth;
+                                $mail->Username   = $smtp_username;
+                                $mail->Password   = $smtp_password;
+                                $mail->SMTPSecure = $smtp_secure;
+                                $mail->Port       = $smtp_port;
 
                                 $mail->setFrom($pwd_reset_from, 'Atarilegend');
                                 $mail->addReplyTo($pwd_reset_reply, 'Atarilegend');

--- a/Website/AtariLegend/php/common/login/db_reset.php
+++ b/Website/AtariLegend/php/common/login/db_reset.php
@@ -66,7 +66,7 @@ if (isset($action) and $action == 'check_email') {
                 $pwrurl = $pwd_reset_link.$password;
 
                 $mail = new PHPMailer(true);
-                
+
 
                 $start = microtime(true);
                 $i     = 0;
@@ -78,20 +78,16 @@ if (isset($action) and $action == 'check_email') {
                 //We need to comment out this comment to have it to work from server, on localhost it runs with this
                 //command $mail->isSMTP(); // Set mailer to use SMTP
 
-                $mail->SMTPDebug  = 0;                            // enables SMTP debug information (for testing)
+                // $mail->SMTPDebug  = 4;                            // enables SMTP debug information (for testing)
                 // 1 = errors and messages
                 // 2 = messages only
-                //$mail->Host = 'smtp.live.com';                    // Specify main and backup SMTP servers
-                $mail->Host       = $ms_host;
-                $mail->SMTPAuth   = true; // Enable SMTP authentication
-                //$mail->Username = 'atarilegend@hotmail.com';      // SMTP username
-                //$mail->Password = '@Tar1L3geNd';                  // SMTP password
-                $mail->Username   = $ms_usn;
-                $mail->Password   = $ms_pwd;
-                $mail->SMTPSecure = 'tls'; // Enable TLS encryption, `ssl` also accepted
-                //$mail->SMTPSecure = 'ssl';
-                //$mail->Port = 587;                                // TCP port to connect to
-                $mail->Port       = $ms_port;
+                $mail->Mailer     = $email_mailer;
+                $mail->Host       = $smtp_host;
+                $mail->SMTPAuth   = $smtp_auth;
+                $mail->Username   = $smtp_username;
+                $mail->Password   = $smtp_password;
+                $mail->SMTPSecure = $smtp_secure;
+                $mail->Port       = $smtp_port;
 
                 $mail->setFrom($pwd_reset_from, 'Atarilegend');
                 $mail->addReplyTo($pwd_reset_reply, 'Atarilegend');

--- a/Website/AtariLegend/php/config/common.php
+++ b/Website/AtariLegend/php/config/common.php
@@ -24,6 +24,20 @@ include("../../lib/functions.php");
 include("../../lib/karma.php");
 include("../../lib/who_is_online.php");
 
+// Define default email config that will get overwritten
+// in email_settings.php
+$email_mailer = 'mail';
+$smtp_host = '';
+$smtp_username = '';
+$smtp_password = '';
+$smtp_port = -1;
+$smtp_auth = false;
+$smtp_secure = '';
+
+// email_settings.php may not exist (to use the default settings)
+// So suppress errors with @
+@include("../../config/email_settings.php");
+
 if (file_exists("../../config/database_upgrade.php")==true) {
     exit("Upgrade mode");
 }

--- a/Website/AtariLegend/php/config/config.php
+++ b/Website/AtariLegend/php/config/config.php
@@ -61,29 +61,6 @@ define("SECURE", false);    // FOR DEVELOPMENT ONLY!!!!
 // Mail server variables -- change these is we change server!
 //***************************************************************
 
-//GMAIL SERVER for testing
-//$ms_usn = 'atarilegendserver@gmail.com';
-//$ms_pwd = '@Tar1L3geNd';
-//$ms_port = 587;
-//$ms_host = 'smtp.gmail.com';
-
-// this is the data used when creating emails regarding reset pwd and registration
-//$pwd_reset_link = "http://dev.stonish.net/php/main/front/front.php?action=new_pwd&q=";
-//$pwd_reset_from = 'atarilegendserver@gmail.com';
-//$pwd_reset_reply = 'atarilegendserver@gmail.com';
-
-//$confirm_account_link = "http://localhost/atarilegend/php/common/login/db_register.php?action=confirm";
-
-//PROD SERVER @ 1and1
-//$ms_usn = '537971048';
-//$ms_pwd = 'Tomsguide1%';
-
-//PROD SERVER @ 1and1 - NEW
-$ms_usn = '172683540';
-$ms_pwd = 'spike99';
-$ms_port = 587;
-$ms_host = 'auth.smtp.1and1.fr';
-
 // this is the data used when creating emails regarding reset pwd and registration
 $pwd_reset_link = "http://www.atarilegend.com/php/main/front/front.php?action=new_pwd&q=";
 $pwd_reset_from = 'admin@atarilegend.com';


### PR DESCRIPTION
- Remove hardcoded credentials. They will still be in the Git history,
but the passwords have been changed on the target system
- Set default email to use the local mail server, rather than SMTP
- Added mechanism to allow a local email config, to be able to send
emails when developing